### PR TITLE
Update device-driver to 1.0.3 and bump MSRV to 1.83

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -204,7 +204,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        msrv: ["1.81"] # We're relying on namespaced-features, which
+        msrv: ["1.83"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
                        # We also depend on `fixed' which requires rust
@@ -218,6 +218,8 @@ jobs:
                        #
                        # device-driver requires 1.81 for a stabilized
                        # core::error module
+                       #
+                       # bitfield-struct requires 1.83
     name: ubuntu / ${{ matrix.msrv }} (${{ matrix.commit }})
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,12 @@ include = [
 edition = "2021"
 
 [dependencies]
-device-driver = { version = "=1.0.0-rc.1", default-features = false, features = ["yaml"] }
+device-driver = { version = "1.0.3", default-features = false, features = ["yaml"] }
 defmt = { version = "0.3", optional = true }
 
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
+embedded-batteries-async = { git = "https://github.com/OpenDevicePartnership/embedded-batteries" }
 
 [dev-dependencies]
 embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A higher level API will be built on top of the lower level register accessor usi
 
 ## MSRV
 
-Currently, rust `1.81` and up is supported.
+Currently, rust `1.83` and up is supported.
 
 ## License
 


### PR DESCRIPTION
bitfield-struct in embedded-batteries-async needs rust version 1.83