### PR TITLE
Add BQ40Z50 R4 registers required for power

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }
 tokio = { version = "1.42.0", features = ["rt", "macros"] }
 
 [lints.rust]
-unsafe_code = "forbid"
+unsafe_code = "deny"
 missing_docs = "deny"
 
 

--- a/device.yaml
+++ b/device.yaml
@@ -1919,7 +1919,6 @@ AVG_CURRENT:
   fields:
     AVG_CURRENT:
       base: int
-      access: RO
       start: 0
       end: 16
 
@@ -3162,26 +3161,26 @@ AFE_REG:
       start: 160
       end: 168
 
-TURBO_POWER:
+MAX_TURBO_POWER:
   type: register
   address: 0x59
   size_bits: 16
   access: RW
   fields:
     TURBO_POWER:
-      base: uint
+      base: int
       access: RW
       start: 0
       end: 16
 
-TURBO_FINAL:
+SUS_TURBO_POWER:
   type: register
   address: 0x5A
   size_bits: 16
   access: RW
   fields:
     TURBO_FINAL:
-      base: uint
+      base: int
       access: RW
       start: 0
       end: 16
@@ -3603,6 +3602,32 @@ LIFETIME_DATA_BLOCK_5:
       access: RO
       start: 240
       end: 256
+
+TURBO_RHF_EFFECTIVE:
+  type: register
+  address: 0x68
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    RESISTANCE :
+      base: int
+      access: RO
+      start: 0
+      end: 16
+
+TURBO_VLOAD:
+  type: register
+  address: 0x69
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    VOLTAGE:
+      base: int
+      access: RO
+      start: 0
+      end: 16
 
 MANUFACTURE_INFO:
   type: buffer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,71 @@ impl<I2C: I2cTrait> Bq40z50<I2C> {
             CapacityModeState::Milliamps
         });
     }
+
+    /// Read data from an arbitrary register from the device.
+    ///
+    /// If the register you are trying to read exists in the manifest file, use that function instead.
+    ///
+    /// Warning: To avoid loss of data, make sure that the `data` slice passed in is large enough to hold all expected data.
+    /// Otherwise an `Overrun` error will be returned.
+    /// Ensure that the register address is valid in the datasheet. Also ensure that the register is able to be written to.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if an I2C bus error occurs.
+    ///
+    /// # Safety
+    ///
+    /// This function should only be called with valid register addresses and data slice size.
+    /// Ensure that the register is able to be written to.
+    #[allow(unsafe_code)]
+    pub async unsafe fn read_register_unchecked(
+        &mut self,
+        reg_address: u8,
+        data: &mut [u8],
+    ) -> Result<(), BQ40Z50Error<I2C::Error>> {
+        self.device
+            .interface
+            .i2c
+            .write_read(BQ_ADDR, &[reg_address], data)
+            .await
+            .map_err(BQ40Z50Error::I2c)
+    }
+
+    /// Write data to an arbitrary register on the device.
+    ///
+    /// If the register you are trying to read exists in the manifest file, use that function instead.
+    ///
+    /// Warning: To avoid loss of data, make sure that the `data` slice passed in is the right size.
+    /// Ensure that the register address is valid in the datasheet. Also ensure that the register is able to be written to.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if an I2C bus error occurs.
+    ///
+    /// # Safety
+    ///
+    /// This function should only be called with valid register addresses and data slice size.
+    /// Ensure that the register is able to be written to.
+    #[allow(unsafe_code)]
+    pub async unsafe fn write_register_unchecked(
+        &mut self,
+        reg_address: u8,
+        data: &[u8],
+    ) -> Result<(), BQ40Z50Error<I2C::Error>> {
+        debug_assert!((data.len() <= LARGEST_REG_SIZE_BYTES), "Register size too big");
+
+        // Add one byte for register address
+        let mut buf = [0u8; 1 + LARGEST_REG_SIZE_BYTES];
+        buf[0] = reg_address;
+        buf[1..=data.len()].copy_from_slice(data);
+        self.device
+            .interface
+            .i2c
+            .write(BQ_ADDR, &buf[..=data.len()])
+            .await
+            .map_err(BQ40Z50Error::I2c)
+    }
 }
 
 impl<I2C: I2cTrait> smart_battery::ErrorType for Bq40z50<I2C> {
@@ -569,6 +634,30 @@ mod tests {
         };
 
         assert_eq!(status.error_code(), ErrorCode::Ok);
+
+        bq.device.interface.i2c.done();
+    }
+
+    #[tokio::test]
+    #[allow(unsafe_code)]
+    async fn test_read_write_unchecked() {
+        let expectations = vec![
+            Transaction::write_read(BQ_ADDR, vec![0x16], vec![0x30, 0x30]),
+            Transaction::write(BQ_ADDR, vec![0x16, 0x2F, 0x30]),
+        ];
+        let i2c = Mock::new(&expectations);
+        let mut bq = Bq40z50::new(i2c);
+
+        let mut data = [0u8; 2];
+
+        unsafe {
+            bq.read_register_unchecked(0x16, &mut data).await.unwrap();
+        }
+        data[0] -= 1;
+
+        unsafe {
+            bq.write_register_unchecked(0x16, &data).await.unwrap();
+        }
 
         bq.device.interface.i2c.done();
     }


### PR DESCRIPTION
Added  following command definitions,
MAX_TURBO_POWER,
SUS_TURBO_POWER,
TURBO_RHF_EFFECTIVE,
TURBO_VLOAD