### PR TITLE
Enable SMBus block reads and writes for MAC commands

### DIFF
--- a/device.yaml
+++ b/device.yaml
@@ -210,62 +210,6 @@ MAC_SEAL:
   type: command
   address: 0x443000
 
-MAC_SECURITY_KEYS:
-  type: command
-  address: 0x443500
-  size_bits_in: 64
-  fields_in:
-    UNSEAL_KEY_A:
-      base: uint
-      start: 0
-      end: 16
-    UNSEAL_KEY_B:
-      base: uint
-      start: 16
-      end: 32
-    FULL_ACCESS_KEY_A:
-      base: uint
-      start: 32
-      end: 48
-    FULL_ACCESS_KEY_B:
-      base: uint
-      start: 48
-      end: 64
-  size_bits_out: 64
-  fields_out:
-    UNSEAL_KEY_A:
-      base: uint
-      start: 0
-      end: 16
-    UNSEAL_KEY_B:
-      base: uint
-      start: 16
-      end: 32
-    FULL_ACCESS_KEY_A:
-      base: uint
-      start: 32
-      end: 48
-    FULL_ACCESS_KEY_B:
-      base: uint
-      start: 48
-      end: 64
-
-MAC_AUTH_KEY:
-  type: command
-  address: 0x443700
-  size_bits_in: 128
-  fields_in:
-    AUTHENTICATION_KEY:
-      base: uint
-      start: 0
-      end: 128
-  size_bits_out: 128
-  fields_out:
-    AUTHENTICATION_KEY:
-      base: uint
-      start: 0
-      end: 128
-
 MAC_DEVICE_RESET:
   type: command
   address: 0x444100


### PR DESCRIPTION
MAC register accesses are interfaced using SMBus Block reads/writes, which are slightly different from regular SMBus reads/writes through the addition of a size field after the register command. 

![block_write](https://github.com/user-attachments/assets/90bc1342-e9bc-417e-b668-df791d8912d0)

![block_read](https://github.com/user-attachments/assets/e8c98768-d993-449f-bc10-8692c54a4343)

In the driver, MAC registers are handled through the AsyncCommandInterface, so this PR adds support for SMBus. Since most commands are either write only or read only, I reworked the `dispatch_command()` fn to perform either a read or a write depending on the register type. The R/W MAC commands are handled in separate special case functions since `dispatch_command()` cannot generate a read only _and_ a write only fn. 

Writes are a simple SMBus block write.
Reads are an SMBus block write with the command 0x44 and the 2 byte register address, immediately followed by an SMBus block read with the command 0x44.