### PR TITLE
Break driver functionality into chip revisions and add initial support for R1, R3, R4, R5

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Get early warning of new lints which are regularly introduced in beta channels.
         toolchain: [stable, beta]
-        chip-rev: [r1, r4]
+        chip-rev: [r1, r3, r4, r5]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,35 +65,40 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   # Enable once we have a released crate
-  semver:
-    runs-on: ubuntu-latest
-    name: semver
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - name: cargo-semver-checks
-        uses: obi1kenobi/cargo-semver-checks-action@v2
+  # UPDATE: Crate is released but because of mutually exclusive features, this will never succeed :c
+  # semver:
+  #   runs-on: ubuntu-latest
+  #   name: semver
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: true
+  #     - name: Install stable
+  #       uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         components: rustfmt
+  #     - name: cargo-semver-checks
+  #       uses: obi1kenobi/cargo-semver-checks-action@v2
 
   doc:
     # run docs generation on nightly rather than stable. This enables features like
     # https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html which allows an
     # API be documented as only available in some specific platforms.
+    # UPDATE: nightly seems broken right now, reverting to stable
     runs-on: ubuntu-latest
-    name: nightly / doc
+    name: stable / doc
     strategy:
       matrix:
-        chip-rev: [r1, r4]
+        chip-rev: [r1, r3, r4, r5]
+        toolchain: [stable]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: ${{ matrix.toolchain }}
       - name: cargo doc ${{ matrix.chip-rev }}
         run: cargo doc --no-deps --features ${{ matrix.chip-rev }}
         env:
@@ -126,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chip-rev: [r1, r4]
+        chip-rev: [r1, r3, r4, r5]
         msrv: ["1.85"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
@@ -142,6 +147,7 @@ jobs:
                        # bitfield-struct requires 1.83
                        #
                        # device-driver requires 1.85 for Rust 2024 edition
+        toolchain: [stable]
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4
@@ -150,6 +156,6 @@ jobs:
       - name: Install ${{ matrix.msrv }}
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.msrv }}
-      - name: cargo +${{ matrix.msrv }} check ${{ matrix.chip-rev }}
+          toolchain: ${{ matrix.toolchain }}
+      - name: cargo +${{ matrix.toolchain }} check ${{ matrix.chip-rev }}
         run: cargo check --features ${{ matrix.chip-rev }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         # Get early warning of new lints which are regularly introduced in beta channels.
         toolchain: [stable, beta]
+        chip-rev: [r1, r4]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,27 +57,27 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
-      - name: cargo clippy
+      - name: cargo clippy ${{ matrix.chip-rev }}
         uses: giraffate/clippy-action@v1
         with:
           reporter: 'github-pr-check'
-          clippy_flags: -- -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style
+          clippy_flags: --features ${{ matrix.chip-rev }} -- -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   # Enable once we have a released crate
-  # semver:
-  #   runs-on: ubuntu-latest
-  #   name: semver
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: true
-  #     - name: Install stable
-  #       uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         components: rustfmt
-  #     - name: cargo-semver-checks
-  #       uses: obi1kenobi/cargo-semver-checks-action@v2
+  semver:
+    runs-on: ubuntu-latest
+    name: semver
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: cargo-semver-checks
+        uses: obi1kenobi/cargo-semver-checks-action@v2
 
   doc:
     # run docs generation on nightly rather than stable. This enables features like
@@ -84,34 +85,19 @@ jobs:
     # API be documented as only available in some specific platforms.
     runs-on: ubuntu-latest
     name: nightly / doc
+    strategy:
+      matrix:
+        chip-rev: [r1, r4]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
-      - name: cargo doc
-        run: cargo doc --no-deps --all-features
+      - name: cargo doc ${{ matrix.chip-rev }}
+        run: cargo doc --no-deps --features ${{ matrix.chip-rev }}
         env:
           RUSTDOCFLAGS: --cfg docsrs
-
-  hack:
-    # cargo-hack checks combinations of feature flags to ensure that features are all additive
-    # which is required for feature unification
-    runs-on: ubuntu-latest
-    name: ubuntu / stable / features
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
-      - name: cargo install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-      # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
-      # --feature-powerset runs for every combination of features
-      - name: cargo hack
-        run: cargo hack --feature-powerset check
 
   deny:
     # cargo-deny checks licenses, advisories, sources, and bans for
@@ -140,6 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        chip-rev: [r1, r4]
         msrv: ["1.85"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
@@ -164,5 +151,5 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.msrv }}
-      - name: cargo +${{ matrix.msrv }} check
-        run: cargo check
+      - name: cargo +${{ matrix.msrv }} check ${{ matrix.chip-rev }}
+        run: cargo check --features ${{ matrix.chip-rev }}

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         target: [thumbv8m.main-none-eabihf]
-        chip-rev: [r1, r4]
+        chip-rev: [r1, r3, r4, r5]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         target: [thumbv8m.main-none-eabihf]
+        chip-rev: [r1, r4]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,5 +27,5 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: rustup target add ${{ matrix.target }}
         run: rustup target add ${{ matrix.target }}
-      - name: cargo check
-        run: cargo check --target ${{ matrix.target }} --no-default-features
+      - name: cargo check ${{ matrix.chip-rev }}
+        run: cargo check --target ${{ matrix.target }} --features ${{ matrix.chip-rev }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
-name = "bq40z50"
+name = "bq40z50-rx"
 version = "0.1.0"
 repository = "https://github.com/OpenDevicePartnership/bq40z50"
 license = "MIT"
+authors = ["Matteo Tullo <matteotullo@microsoft.com>"]
+rust-version = "1.85"
 description = "Platform-agnostic Rust driver for the Texas Instruments BQ40Z50 battery fuel (gas) gauge."
 readme = "README.md"
-keywords = ["bq40z50", "TI", "Texas Instruments", "battery", "fuel", "gas", "gauge", "i2c", "driver", "embedded-hal-driver"]
+keywords = ["TI", "battery", "fuel-gauge", "i2c", "driver"]
 categories = ["embedded", "hardware-support", "no-std"]
 documentation = "https://docs.rs/bq40z50"
 include = [
@@ -13,12 +15,14 @@ include = [
 	"/Cargo.toml",
 	"/README.md",
 	"/LICENSE",
-	"/device.yaml",
+	"/device_R*.yaml",
 ]
 edition = "2024"
 
 [dependencies]
-device-driver = { version = "1.0.3", default-features = false, features = ["yaml"] }
+device-driver = { version = "1.0.3", default-features = false, features = [
+	"yaml",
+] }
 defmt = { version = "0.3", optional = true }
 
 embedded-hal = "1.0.0"
@@ -42,4 +46,10 @@ style = "forbid"
 pedantic = "deny"
 
 [features]
-defmt-03 = ["dep:defmt", "device-driver/defmt-03", "embedded-batteries-async/defmt"]
+defmt-03 = [
+	"dep:defmt",
+	"device-driver/defmt-03",
+	"embedded-batteries-async/defmt",
+]
+r1 = []
+r4 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,4 +52,6 @@ defmt-03 = [
 	"embedded-batteries-async/defmt",
 ]
 r1 = []
+r3 = []
 r4 = []
+r5 = []

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # BQ40Z50 Rust Device Driver
 
-A `#[no_std]` platform-agnostic driver for the [BQ40Z50](https://www.ti.com/lit/ug/sluua43a/sluua43a.pdf) family of lithium-ion battery fuel/gas gauge, capable of managing a 1- to 4-cell battery, using the [embedded-hal](https://docs.rs/embedded-hal) traits.
+A `#[no_std]` platform-agnostic driver for the [BQ40Z50](https://www.ti.com/product/BQ40Z50) family of lithium-ion battery fuel/gas gauge, capable of managing a 1- to 4-cell battery, using the [embedded-hal](https://docs.rs/embedded-hal) traits.
 
 A higher level API exposing standard Smart Battery Specification functions is built on top of the lower level register accessor using the [embedded-batteries](https://github.com/OpenDevicePartnership/embedded-batteries) traits.
 
+Four revisions of the chip are currently supported:
+- [BQ40Z50](https://www.ti.com/lit/ug/sluua43a/sluua43a.pdf)
+- [BQ40Z50-R3](https://www.ti.com/lit/ug/sluubu5a/sluubu5a.pdf)
+- [BQ40Z50-R4](https://www.ti.com/lit/ug/sluuch2/sluuch2.pdf)
+- [BQ40Z50-R5](https://www.ti.com/lit/ug/sluucn4b/sluucn4b.pdf)
+
+Please choose which revision you are using by enabling the appropriate feature.
 
 ## MSRV
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # BQ40Z50 Rust Device Driver
 
-A `#[no_std]` platform-agnostic driver for the [BQ40Z50](https://www.ti.com/lit/ug/sluua43a/sluua43a.pdf) lithium-ion battery fuel/gas gauge, capable of managing a 1- to 4-cell battery, using the [embedded-hal](https://docs.rs/embedded-hal) traits.
+A `#[no_std]` platform-agnostic driver for the [BQ40Z50](https://www.ti.com/lit/ug/sluua43a/sluua43a.pdf) family of lithium-ion battery fuel/gas gauge, capable of managing a 1- to 4-cell battery, using the [embedded-hal](https://docs.rs/embedded-hal) traits.
 
-A higher level API will be built on top of the lower level register accessor using the [embedded-batteries](https://github.com/OpenDevicePartnership/embedded-batteries) traits.
+A higher level API exposing standard Smart Battery Specification functions is built on top of the lower level register accessor using the [embedded-batteries](https://github.com/OpenDevicePartnership/embedded-batteries) traits.
 
 
 ## MSRV

--- a/build.rs
+++ b/build.rs
@@ -2,12 +2,23 @@
 fn main() {
     #[cfg(feature = "r1")]
     println!("cargo:rebuild-if-changed=device_R1.yaml");
+    #[cfg(feature = "r3")]
+    println!("cargo:rebuild-if-changed=device_R3.yaml");
     #[cfg(feature = "r4")]
     println!("cargo:rebuild-if-changed=device_R4.yaml");
+    #[cfg(feature = "r5")]
+    println!("cargo:rebuild-if-changed=device_R5.yaml");
 
-    #[cfg(not(any(feature = "r1", feature = "r4")))]
+    #[cfg(not(any(feature = "r1", feature = "r3", feature = "r4", feature = "r5")))]
     compile_error!("Please enable a chip revision feature that corresponds to the one you are using!");
 
-    #[cfg(all(feature = "r1", feature = "r4"))]
+    #[cfg(any(
+        all(feature = "r1", feature = "r3"),
+        all(feature = "r1", feature = "r4"),
+        all(feature = "r1", feature = "r5"),
+        all(feature = "r3", feature = "r4"),
+        all(feature = "r3", feature = "r5"),
+        all(feature = "r4", feature = "r5"),
+    ))]
     compile_error!("Please enable only one chip revision that corresponds to the one you are using!");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,13 @@
 #![allow(missing_docs)]
 fn main() {
-    println!("cargo:rebuild-if-changed=device.yaml");
+    #[cfg(feature = "r1")]
+    println!("cargo:rebuild-if-changed=device_R1.yaml");
+    #[cfg(feature = "r4")]
+    println!("cargo:rebuild-if-changed=device_R4.yaml");
+
+    #[cfg(not(any(feature = "r1", feature = "r4")))]
+    compile_error!("Please enable a chip revision feature that corresponds to the one you are using!");
+
+    #[cfg(all(feature = "r1", feature = "r4"))]
+    compile_error!("Please enable only one chip revision that corresponds to the one you are using!");
 }

--- a/device_R1.yaml
+++ b/device_R1.yaml
@@ -1,0 +1,4043 @@
+config:
+  register_address_type: u8
+  command_address_type: u32
+  buffer_address_type: u8
+  default_byte_order: LE
+  default_bit_order: LSB0
+  defmt_feature: defmt-03
+
+MAC_DEVICE_TYPE:
+  type: command
+  address: 0x440100
+  size_bits_out: 16
+  fields_out:
+    DEVICE_TYPE:
+      base: uint
+      start: 0
+      end: 16
+  description: |
+    The device can be checked for the IC part number.
+
+MAC_FIRMWARE_VERSION:
+  type: command
+  address: 0x440200
+  size_bits_out: 88
+  fields_out:
+    DEVICE_NUMBER:
+      base: uint
+      start: 0
+      end: 16
+    VERSION:
+      base: uint
+      start: 16
+      end: 32
+    BUILD_NUMBER:
+      base: uint
+      start: 32
+      end: 48
+    FIRMWARE_TYPE:
+      base: uint
+      start: 48
+      end: 56
+    IMPEDENCE_TRACK_VERS:
+      base: uint
+      start: 56
+      end: 72
+  description: |
+    The device can be checked for the firmware version of the IC.
+
+MAC_HARDWARE_VERSION:
+  type: command
+  address: 0x440300
+  size_bits_out: 8
+  fields_out:
+    HW_VERS:
+      base: uint
+      start: 0
+      end: 8
+
+MAC_INSTRUCTION_FLASH_SIGNATURE:
+  type: command
+  address: 0x440400
+  size_bits_out: 8
+  fields_out:
+    INSN_FLSH_SIG:
+      base: uint
+      start: 0
+      end: 8
+
+MAC_STATIC_DF_SIGNATURE:
+  type: command
+  address: 0x440500
+  size_bits_out: 16
+  fields_out:
+    STATIC_DF_SIG:
+      base: uint
+      start: 0
+      end: 15
+    SIG_MISMATCH:
+      base: bool
+      start: 15
+
+MAC_CHEM_ID:
+  type: command
+  address: 0x440600
+  size_bits_out: 8
+  fields_out:
+    CHEM_ID:
+      base: uint
+      start: 0
+      end: 8
+
+MAC_STATIC_CHEM_DF_SIG:
+  type: command
+  address: 0x440800
+  size_bits_out: 16
+  fields_out:
+    STATIC_CHEM_DF_SIG:
+      base: uint
+      start: 0
+      end: 15
+    SIG_MISMATCH:
+      base: bool
+      start: 15
+
+MAC_ALL_DF_SIGNATURE:
+  type: command
+  address: 0x440900
+  size_bits_out: 16
+  fields_out:
+    STATIC_CHEM_DF_SIG:
+      base: uint
+      start: 0
+      end: 15
+    SIG_MISMATCH:
+      base: bool
+      start: 15
+
+MAC_SHUTDOWN_MODE:
+  type: command
+  address: 0x441000
+
+MAC_SLEEP_MODE:
+  type: command
+  address: 0x441100
+
+MAC_AUTO_CC_OFFSET:
+  type: command
+  address: 0x441300
+
+MAC_FUSE_TOGGLE:
+  type: command
+  address: 0x441D00
+
+MAC_PCHG_FET_TOGGLE:
+  type: command
+  address: 0x441E00
+
+MAC_CHG_FET_TOGGLE:
+  type: command
+  address: 0x441F00
+
+MAC_DSG_FET_TOGGLE:
+  type: command
+  address: 0x442000
+
+MAC_GAUGING:
+  type: command
+  address: 0x442100
+  description: |
+    This command enables or disables the gauging function to ease
+    testing during manufacturing. 
+
+MAC_FET_CTRL:
+  type: command
+  address: 0x442200
+
+MAC_LIFETIME_DATA_COLLECTION:
+  type: command
+  address: 0x442300
+
+MAC_PERMANENT_FAILURE:
+  type: command
+  address: 0x442400
+
+MAC_BLACK_BLOCK_RECORDER:
+  type: command
+  address: 0x442500
+
+MAC_FUSE:
+  type: command
+  address: 0x442600
+
+MAC_LED_DISP_EN:
+  type: command
+  address: 0x442700
+
+MAC_LIFETIME_DATA_RST:
+  type: command
+  address: 0x442800
+
+MAC_PF_DATA_RST:
+  type: command
+  address: 0x442900
+
+MAC_BLK_BOX_REC_RESET:
+  type: command
+  address: 0x442A00
+
+MAC_LED_TOGGLE:
+  type: command
+  address: 0x442B00
+
+MAC_LED_DISP_PRESS:
+  type: command
+  address: 0x442C00
+
+MAC_CALIBRATION_MODE:
+  type: command
+  address: 0x442D00
+
+MAC_LIFETIME_DATA_FLUSH:
+  type: command
+  address: 0x442E00
+
+MAC_LIFETIME_DATA_SPEED_UP_MODE:
+  type: command
+  address: 0x442F00
+
+MAC_SEAL:
+  type: command
+  address: 0x443000
+
+MAC_DEVICE_RESET:
+  type: command
+  address: 0x444100
+
+MAC_SAFETY_ALERT:
+  type: command
+  address: 0x445000
+  size_bits_out: 32
+  fields_out:
+    CUV:
+      base: bool
+      start: 0
+    COV:
+      base: bool
+      start: 1
+    OCC1:
+      base: bool
+      start: 2
+    OCC2:
+      base: bool
+      start: 3
+    OCD1:
+      base: bool
+      start: 4
+    OCD2:
+      base: bool
+      start: 5
+    AOLDL:
+      base: bool
+      start: 7
+    ASCCL:
+      base: bool
+      start: 9
+    ASCDL:
+      base: bool
+      start: 11
+    OTC:
+      base: bool
+      start: 12
+    OTD:
+      base: bool
+      start: 13
+    CUVC:
+      base: bool
+      start: 14
+    OTF:
+      base: bool
+      start: 16
+    PTO:
+      base: bool
+      start: 18
+    PTOS:
+      base: bool
+      start: 19
+    CTO:
+      base: bool
+      start: 20
+    CTOS:
+      base: bool
+      start: 21
+    OC:
+      base: bool
+      start: 22
+    CHGC:
+      base: bool
+      start: 23
+    CHGV:
+      base: bool
+      start: 24
+    PCHGC:
+      base: bool
+      start: 25
+    UTC:
+      base: bool
+      start: 26
+    UTD:
+      base: bool
+      start: 27
+
+MAC_SAFETY_STATUS:
+  type: command
+  address: 0x445100
+  size_bits_out: 32
+  fields_out:
+    CUV:
+      base: bool
+      start: 0
+    COV:
+      base: bool
+      start: 1
+    OCC1:
+      base: bool
+      start: 2
+    OCC2:
+      base: bool
+      start: 3
+    OCD1:
+      base: bool
+      start: 4
+    OCD2:
+      base: bool
+      start: 5
+    AOLD:
+      base: bool
+      start: 6
+    AOLDL:
+      base: bool
+      start: 7
+    ASCC:
+      base: bool
+      start: 8
+    ASCCL:
+      base: bool
+      start: 9
+    ASCD:
+      base: bool
+      start: 10
+    ASCDL:
+      base: bool
+      start: 11
+    OTC:
+      base: bool
+      start: 12
+    OTD:
+      base: bool
+      start: 13
+    CUVC:
+      base: bool
+      start: 14
+    OTF:
+      base: bool
+      start: 16
+    PTO:
+      base: bool
+      start: 18
+    PTOS:
+      base: bool
+      start: 19
+    CTO:
+      base: bool
+      start: 20
+    OC:
+      base: bool
+      start: 22
+    CHGC:
+      base: bool
+      start: 23
+    CHGV:
+      base: bool
+      start: 24
+    PCHGC:
+      base: bool
+      start: 25
+    UTC:
+      base: bool
+      start: 26
+    UTD:
+      base: bool
+      start: 27
+
+MAC_PF_ALERT:
+  type: command
+  address: 0x445200
+  size_bits_out: 32
+  fields_out:
+    SUV:
+      base: bool
+      start: 0
+    SOV:
+      base: bool
+      start: 1
+    SOCC:
+      base: bool
+      start: 2
+    SOCD:
+      base: bool
+      start: 3
+    SOT:
+      base: bool
+      start: 4
+    SOTF:
+      base: bool
+      start: 6
+    QIM:
+      base: bool
+      start: 7
+    CB:
+      base: bool
+      start: 8
+    IMP:
+      base: bool
+      start: 9
+    CD:
+      base: bool
+      start: 10
+    VIMR:
+      base: bool
+      start: 11
+    VIMA:
+      base: bool
+      start: 12
+    CFETF:
+      base: bool
+      start: 16
+    DFETF:
+      base: bool
+      start: 17
+    FUSE:
+      base: bool
+      start: 19
+    AFER:
+      base: bool
+      start: 20
+    AFEC:
+      base: bool
+      start: 21
+    SECOND_LVL:
+      base: bool
+      start: 22
+    OPNC:
+      base: bool
+      start: 25
+    TS1:
+      base: bool
+      start: 28
+    TS2:
+      base: bool
+      start: 29
+    TS3:
+      base: bool
+      start: 30
+    TS4:
+      base: bool
+      start: 31
+
+MAC_PF_STATUS:
+  type: command
+  address: 0x445300
+  size_bits_out: 32
+  fields_out:
+    SUV:
+      base: bool
+      start: 0
+    SOV:
+      base: bool
+      start: 1
+    SOCC:
+      base: bool
+      start: 2
+    SOCD:
+      base: bool
+      start: 3
+    SOT:
+      base: bool
+      start: 4
+    SOTF:
+      base: bool
+      start: 6
+    QIM:
+      base: bool
+      start: 7
+    CB:
+      base: bool
+      start: 8
+    IMP:
+      base: bool
+      start: 9
+    CD:
+      base: bool
+      start: 10
+    VIMR:
+      base: bool
+      start: 11
+    VIMA:
+      base: bool
+      start: 12
+    CFETF:
+      base: bool
+      start: 16
+    DFETF:
+      base: bool
+      start: 17
+    FUSE:
+      base: bool
+      start: 19
+    AFER:
+      base: bool
+      start: 20
+    AFEC:
+      base: bool
+      start: 21
+    SECOND_LVL:
+      base: bool
+      start: 22
+    PTC:
+      base: bool
+      start: 23
+    IFC:
+      base: bool
+      start: 24
+    OPNCELL:
+      base: bool
+      start: 25
+    DFW:
+      base: bool
+      start: 26
+    TS1:
+      base: bool
+      start: 28
+    TS2:
+      base: bool
+      start: 29
+    TS3:
+      base: bool
+      start: 30
+    TS4:
+      base: bool
+      start: 31
+
+MAC_OPERATION_STATUS:
+  type: command
+  address: 0x445400
+  size_bits_out: 32
+  fields_out:
+    PRES:
+      base: bool
+      start: 0
+    DSG:
+      base: bool
+      start: 1
+    CHG:
+      base: bool
+      start: 2
+    PCHG:
+      base: bool
+      start: 3
+    FUSE:
+      base: bool
+      start: 5
+    BTP_INT:
+      base: bool
+      start: 7
+    SEC:
+      base: uint
+      start: 8
+      end: 10
+      conversion:
+        name: "MACSecurityMode"
+        Reserved: 0
+        FullAccess: 1
+        UnSealed: 2
+        Sealed: 3
+    SDV:
+      base: bool
+      start: 10
+    SS:
+      base: bool
+      start: 11
+    PF:
+      base: bool
+      start: 12
+    XDSG:
+      base: bool
+      start: 13
+    XCHG:
+      base: bool
+      start: 14
+    SLEEP:
+      base: bool
+      start: 15
+    SDM:
+      base: bool
+      start: 16
+    LED:
+      base: bool
+      start: 17
+    AUTH:
+      base: bool
+      start: 18
+    AUTOCALM:
+      base: bool
+      start: 19
+    CAL:
+      base: bool
+      start: 20
+    CAL_OFFSET:
+      base: bool
+      start: 21
+    XL:
+      base: bool
+      start: 22
+    SLEEPM:
+      base: bool
+      start: 23
+    INIT:
+      base: bool
+      start: 24
+    SMBLCAL:
+      base: bool
+      start: 25
+    SLPAD:
+      base: bool
+      start: 26
+    SLPCC:
+      base: bool
+      start: 27
+    CB:
+      base: bool
+      start: 28
+    EMSHUT:
+      base: bool
+      start: 29
+
+MAC_CHARGING_STATUS:
+  type: command
+  address: 0x445500
+  size_bits_out: 32
+  fields_out:
+    UT:
+      base: bool
+      start: 0
+    LT:
+      base: bool
+      start: 1
+    STL:
+      base: bool
+      start: 2
+    RT:
+      base: bool
+      start: 3
+    STH:
+      base: bool
+      start: 4
+    HT:
+      base: bool
+      start: 5
+    OT:
+      base: bool
+      start: 6
+    PV:
+      base: bool
+      start: 8
+    LV:
+      base: bool
+      start: 9
+    MV:
+      base: bool
+      start: 10
+    HV:
+      base: bool
+      start: 11
+    CHG_IN:
+      base: bool
+      start: 12
+    MCHG:
+      base: bool
+      start: 13
+    VCT:
+      base: bool
+      start: 14
+    CCR:
+      base: bool
+      start: 15
+    CVR:
+      base: bool
+      start: 16
+    CCC:
+      base: bool
+      start: 17
+
+MAC_GAUGING_STATUS:
+  type: command
+  address: 0x445600
+  size_bits_out: 32
+  fields_out:
+    FD:
+      base: bool
+      start: 0
+    FC:
+      base: bool
+      start: 1
+    TD:
+      base: bool
+      start: 2
+    TC:
+      base: bool
+      start: 3
+    BAL_EN:
+      base: bool
+      start: 4
+    EDV:
+      base: bool
+      start: 5
+    DSG:
+      base: bool
+      start: 6
+    CF:
+      base: bool
+      start: 7
+    REST:
+      base: bool
+      start: 8
+    R_DIS:
+      base: bool
+      start: 10
+    VOK:
+      base: bool
+      start: 11
+    QEN:
+      base: bool
+      start: 12
+    SLPQMAX:
+      base: bool
+      start: 13
+    NSFM:
+      base: bool
+      start: 15
+    VDQ:
+      base: bool
+      start: 16
+    QMAX:
+      base: bool
+      start: 17
+    RX:
+      base: bool
+      start: 18
+    LDMD:
+      base: bool
+      start: 19
+    OCVFR:
+      base: bool
+      start: 20
+
+MAC_MANUFACTURING_STATUS:
+  type: command
+  address: 0x445700
+  size_bits_out: 16
+  fields_out:
+    PCHG_EN:
+      base: bool
+      start: 0
+    CHG_EN:
+      base: bool
+      start: 1
+    DSG_EN:
+      base: bool
+      start: 2
+    GAUGE_EN:
+      base: bool
+      start: 3
+    FET_EN:
+      base: bool
+      start: 4
+    LF_EN:
+      base: bool
+      start: 5
+    PF_EN:
+      base: bool
+      start: 6
+    BBR_EN:
+      base: bool
+      start: 7
+    FUSE_EN:
+      base: bool
+      start: 8
+    LED_EN:
+      base: bool
+      start: 9
+    LT_TEST:
+      base: bool
+      start: 14
+    CAL_TEST:
+      base: bool
+      start: 15
+
+MAC_AFE_REG:
+  type: command
+  address: 0x445800
+  size_bits_out: 168
+  fields_out:
+    AFE_INT_STATUS:
+      base: uint
+      start: 0
+      end: 8
+    AFE_FET_STATUS:
+      base: uint
+      start: 8
+      end: 16
+    AFE_RXIN:
+      base: uint
+      start: 16
+      end: 24
+    AFE_LATCH_STATUS:
+      base: uint
+      start: 24
+      end: 32
+    AFE_INT_EN:
+      base: uint
+      start: 32
+      end: 40
+    AFE_CTRL:
+      base: uint
+      start: 40
+      end: 48
+    AFE_RXIEN:
+      base: uint
+      start: 48
+      end: 56
+    AFE_RLOUT:
+      base: uint
+      start: 56
+      end: 64
+    AFE_RHOUT:
+      base: uint
+      start: 64
+      end: 72
+    AFE_RHINT:
+      base: uint
+      start: 72
+      end: 80
+    AFE_CELL_BALANCE:
+      base: uint
+      start: 80
+      end: 88
+    AFE_ADC_CC_CTRL:
+      base: uint
+      start: 88
+      end: 96
+    AFE_ADC_MUX_CTRL:
+      base: uint
+      start: 96
+      end: 104
+    AFE_LED_CTRL:
+      base: uint
+      start: 104
+      end: 112
+    AFE_HW_CTRL:
+      base: uint
+      start: 112
+      end: 120
+    AFE_TMR_CTRL:
+      base: uint
+      start: 120
+      end: 128
+    AFE_PROTECTION:
+      base: uint
+      start: 128
+      end: 136
+    AFE_OCD:
+      base: uint
+      start: 136
+      end: 144
+    AFE_SCC:
+      base: uint
+      start: 144
+      end: 152
+    AFE_SCD1:
+      base: uint
+      start: 152
+      end: 160
+    AFE_SCD2:
+      base: uint
+      start: 160
+      end: 168
+
+MAC_LIFETIME_DATA_BLOCK_1:
+  type: command
+  address: 0x446000
+  size_bits_out: 256
+  fields_out:
+    CELL_1_MAX_V:
+      base: uint
+      start: 0
+      end: 16
+    CELL_2_MAX_V:
+      base: uint
+      start: 16
+      end: 32
+    CELL_3_MAX_V:
+      base: uint
+      start: 32
+      end: 48
+    CELL_4_MAX_V:
+      base: uint
+      start: 48
+      end: 64
+    CELL_1_MIN_V:
+      base: uint
+      start: 64
+      end: 80
+    CELL_2_MIN_V:
+      base: uint
+      start: 80
+      end: 96
+    CELL_3_MIN_V:
+      base: uint
+      start: 96
+      end: 112
+    CELL_4_MIN_V:
+      base: uint
+      start: 112
+      end: 128
+    MAX_DELTA_CELL_V:
+      base: uint
+      start: 128
+      end: 144
+    MAX_CHARGE_A:
+      base: uint
+      start: 144
+      end: 160
+    MAX_DISCHARGE_A:
+      base: uint
+      start: 160
+      end: 176
+    MAX_AVG_DISCHARGE_A:
+      base: uint
+      start: 176
+      end: 192
+    MAX_AVG_DISCHARGE_PWR:
+      base: uint
+      start: 192
+      end: 208
+    MAX_TEMP_CELL:
+      base: uint
+      start: 208
+      end: 216
+    MIN_TEMP_CELL:
+      base: uint
+      start: 216
+      end: 224
+    MAX_DELTA_CELL_TEMP:
+      base: uint
+      start: 224
+      end: 232
+    MAX_TEMP_INT_SENSOR:
+      base: uint
+      start: 232
+      end: 240
+    MIN_TEMP_INT_SENSOR:
+      base: uint
+      start: 240
+      end: 248
+    MAX_TEMP_FET:
+      base: uint
+      start: 248
+      end: 256
+
+MAC_LIFETIME_DATA_BLOCK_2:
+  type: command
+  address: 0x446100
+  size_bits_out: 64
+  fields_out:
+    NUM_SHUTDOWNS:
+      base: uint
+      start: 0
+      end: 8
+    NUM_PART_RESETS:
+      base: uint
+      start: 8
+      end: 16
+    NUM_FULL_RESETS:
+      base: uint
+      start: 16
+      end: 24
+    NUM_WDT_RESETS:
+      base: uint
+      start: 24
+      end: 32
+    CB_TIME_CELL_1:
+      base: uint
+      start: 32
+      end: 40
+    CB_TIME_CELL_2:
+      base: uint
+      start: 40
+      end: 48
+    CB_TIME_CELL_3:
+      base: uint
+      start: 48
+      end: 56
+    CB_TIME_CELL_4:
+      base: uint
+      start: 56
+      end: 64
+
+MAC_LIFETIME_DATA_BLOCK_3:
+  type: command
+  address: 0x446200
+  size_bits_out: 128
+  fields_out:
+    TOTAL_FW_RUNTIME:
+      base: uint
+      start: 0
+      end: 16
+    TIME_SPENT_IN_UT:
+      base: uint
+      start: 16
+      end: 32
+    TIME_SPENT_IN_LT:
+      base: uint
+      start: 32
+      end: 48
+    TIME_SPENT_IN_STL:
+      base: uint
+      start: 48
+      end: 64
+    TIME_SPENT_IN_RT:
+      base: uint
+      start: 64
+      end: 80
+    TIME_SPENT_IN_STH:
+      base: uint
+      start: 80
+      end: 96
+    TIME_SPENT_IN_HT:
+      base: uint
+      start: 96
+      end: 112
+    TIME_SPENT_IN_OT:
+      base: uint
+      start: 112
+      end: 128
+
+MAC_LIFETIME_DATA_BLOCK_4:
+  type: command
+  address: 0x446300
+  size_bits_out: 256
+  fields_out:
+    NUM_COV_EVENTS:
+      base: uint
+      start: 0
+      end: 16
+    LAST_COV_EVENT:
+      base: uint
+      start: 16
+      end: 32
+    NUM_CUV_EVENTS:
+      base: uint
+      start: 32
+      end: 48
+    LAST_CUV_EVENT:
+      base: uint
+      start: 48
+      end: 64
+    NUM_OCD1_EVENT:
+      base: uint
+      start: 64
+      end: 80
+    LAST_OCD1_EVENT:
+      base: uint
+      start: 80
+      end: 96
+    NUM_OCD2_EVENTS:
+      base: uint
+      start: 96
+      end: 112
+    LAST_OCD2_EVENT:
+      base: uint
+      start: 112
+      end: 128
+    NUM_OCC1_EVENTS:
+      base: uint
+      start: 128
+      end: 144
+    LAST_OCC1_EVENT:
+      base: uint
+      start: 144
+      end: 160
+    NUM_OCC2_EVENTS:
+      base: uint
+      start: 160
+      end: 176
+    LAST_OCC2_EVENT:
+      base: uint
+      start: 176
+      end: 192
+    NUM_AOLD_EVENTS:
+      base: uint
+      start: 192
+      end: 208
+    LAST_AOLD_EVENT:
+      base: uint
+      start: 208
+      end: 224
+    NUM_ASCD_EVENTS:
+      base: uint
+      start: 224
+      end: 240
+    LAST_ASCD_EVENT:
+      base: uint
+      start: 240
+      end: 256
+
+MAC_LIFETIME_DATA_BLOCK_5:
+  type: command
+  address: 0x446400
+  size_bits_out: 256
+  fields_out:
+    NUM_ASCC_EVENTS:
+      base: uint
+      start: 0
+      end: 16
+    LAST_ASCC_EVENT:
+      base: uint
+      start: 16
+      end: 32
+    NUM_OTC_EVENTS:
+      base: uint
+      start: 32
+      end: 48
+    LAST_OTC_EVENT:
+      base: uint
+      start: 48
+      end: 64
+    NUM_OTD_EVENT:
+      base: uint
+      start: 64
+      end: 80
+    LAST_OTD_EVENT:
+      base: uint
+      start: 80
+      end: 96
+    NUM_OTF_EVENTS:
+      base: uint
+      start: 96
+      end: 112
+    LAST_OTF_EVENT:
+      base: uint
+      start: 112
+      end: 128
+    NUM_VALID_CHG_TERM:
+      base: uint
+      start: 128
+      end: 144
+    LAST_VALID_CHG_TERM:
+      base: uint
+      start: 144
+      end: 160
+    NUM_QMAX_UPDATES:
+      base: uint
+      start: 160
+      end: 176
+    LAST_QMAX_UPDATE:
+      base: uint
+      start: 176
+      end: 192
+    NUM_RA_UPDATES:
+      base: uint
+      start: 192
+      end: 208
+    LAST_RA_UPDATE:
+      base: uint
+      start: 208
+      end: 224
+    NUM_RA_DISABLE:
+      base: uint
+      start: 224
+      end: 240
+    LAST_RA_DISABLE:
+      base: uint
+      start: 240
+      end: 256
+
+MAC_MANUFACTURE_INFO:
+  type: command
+  address: 0x447000
+  size_bits_out: 256
+  fields_out:
+    MANUFACTURE_INFO_0:
+      base: uint
+      start: 0
+      end: 64
+    MANUFACTURE_INFO_1:
+      base: uint
+      start: 64
+      end: 128
+    MANUFACTURE_INFO_2:
+      base: uint
+      start: 128
+      end: 192
+    MANUFACTURE_INFO_3:
+      base: uint
+      start: 192
+      end: 256
+
+MAC_DA_STATUS_1:
+  type: command
+  address: 0x447100
+  size_bits_out: 256
+  fields_out:
+    CELL_VOLTAGE_1:
+      base: uint
+      start: 0
+      end: 16
+    CELL_VOLTAGE_2:
+      base: uint
+      start: 16
+      end: 32
+    CELL_VOLTAGE_3:
+      base: uint
+      start: 32
+      end: 48
+    CELL_VOLTAGE_4:
+      base: uint
+      start: 48
+      end: 64
+    BAT_VOLTAGE:
+      base: uint
+      start: 64
+      end: 80
+    PACK_VOLTAGE:
+      base: uint
+      start: 80
+      end: 96
+    CELL_CURRENT_1:
+      base: uint
+      start: 96
+      end: 112
+    CELL_CURRENT_2:
+      base: uint
+      start: 112
+      end: 128
+    CELL_CURRENT_3:
+      base: uint
+      start: 128
+      end: 144
+    CELL_CURRENT_4:
+      base: uint
+      start: 144
+      end: 160
+    CELL_PWR_1:
+      base: uint
+      start: 160
+      end: 176
+    CELL_PWR_2:
+      base: uint
+      start: 176
+      end: 192
+    CELL_PWR_3:
+      base: uint
+      start: 192
+      end: 208
+    CELL_PWR_4:
+      base: uint
+      start: 208
+      end: 224
+    TOTAL_PWR:
+      base: uint
+      start: 224
+      end: 240
+    AVG_PWR:
+      base: uint
+      start: 240
+      end: 256
+
+MAC_DA_STATUS_2:
+  type: command
+  address: 0x447200
+  size_bits_out: 112
+  fields_out:
+    INT_TEMP:
+      base: uint
+      start: 0
+      end: 16
+    TS1_TEMP:
+      base: uint
+      start: 16
+      end: 32
+    TS2_TEMP:
+      base: uint
+      start: 32
+      end: 48
+    TS3_TEMP:
+      base: uint
+      start: 48
+      end: 64
+    TS4_TEMP:
+      base: uint
+      start: 64
+      end: 80
+    CELL_TEMP:
+      base: uint
+      start: 80
+      end: 96
+    FET_TEMP:
+      base: uint
+      start: 96
+      end: 112
+
+MAC_GAUGE_STATUS_1:
+  type: command
+  address: 0x447300
+  size_bits_out: 256
+  fields_out:
+    TRUE_REM_Q:
+      base: uint
+      start: 0
+      end: 16
+    TRUE_REM_E:
+      base: uint
+      start: 16
+      end: 32
+    INITIAL_Q:
+      base: uint
+      start: 32
+      end: 48
+    INITIAL_E:
+      base: uint
+      start: 48
+      end: 64
+    TRUE_FCC_Q:
+      base: uint
+      start: 64
+      end: 80
+    TRUE_FCC_E:
+      base: uint
+      start: 80
+      end: 96
+    T_SIM:
+      base: uint
+      start: 96
+      end: 112
+    T_AMBIENT:
+      base: uint
+      start: 112
+      end: 128
+    RA_SCALE_0:
+      base: uint
+      start: 128
+      end: 144
+    RA_SCALE_1:
+      base: uint
+      start: 144
+      end: 160
+    RA_SCALE_2:
+      base: uint
+      start: 160
+      end: 176
+    RA_SCALE_3:
+      base: uint
+      start: 176
+      end: 192
+    COMP_RES_0:
+      base: uint
+      start: 192
+      end: 208
+    COMP_RES_1:
+      base: uint
+      start: 208
+      end: 224
+    COMP_RES_2:
+      base: uint
+      start: 224
+      end: 240
+    COMP_RES_3:
+      base: uint
+      start: 240
+      end: 256
+
+MAC_GAUGE_STATUS_2:
+  type: command
+  address: 0x447400
+  size_bits_out: 256
+  fields_out:
+    PACK_GRID:
+      base: uint
+      start: 0
+      end: 8
+    Q_MAX_STATUS:
+      base: uint
+      start: 8
+      end: 10
+      conversion:
+        name: "MACQMaxStatus"
+        BattOK: 0
+        QMaxUpdated: 1
+        QMaxRTableUpdated: 2
+        Reserved: 3
+    ITEN:
+      base: bool
+      start: 10
+    QMAX_FIELD_UPDATED:
+      base: bool
+      start: 11
+    CELL_GRID_0:
+      base: uint
+      start: 16
+      end: 24
+    CELL_GRID_1:
+      base: uint
+      start: 24
+      end: 32
+    CELL_GRID_2:
+      base: uint
+      start: 32
+      end: 40
+    CELL_GRID_3:
+      base: uint
+      start: 40
+      end: 48
+    STATE_TIME:
+      base: uint
+      start: 48
+      end: 80
+    DOD0_0:
+      base: uint
+      start: 80
+      end: 96
+    DOD0_1:
+      base: uint
+      start: 96
+      end: 112
+    DOD0_2:
+      base: uint
+      start: 112
+      end: 128
+    DOD0_3:
+      base: uint
+      start: 128
+      end: 144
+    DOD0_PASSED_Q:
+      base: uint
+      start: 144
+      end: 160
+    DOD0_PASSED_E:
+      base: uint
+      start: 160
+      end: 176
+    DOD0_TIME:
+      base: uint
+      start: 176
+      end: 192
+    DODEOC_0:
+      base: uint
+      start: 192
+      end: 208
+    DODEOC_1:
+      base: uint
+      start: 208
+      end: 224
+    DODEOC_2:
+      base: uint
+      start: 224
+      end: 240
+    DODEOC_3:
+      base: uint
+      start: 240
+      end: 256
+
+MAC_GAUGE_STATUS_3:
+  type: command
+  address: 0x447500
+  size_bits_out: 192
+  fields_out:
+    QMAX_0:
+      base: uint
+      start: 0
+      end: 16
+    QMAX_1:
+      base: uint
+      start: 16
+      end: 32
+    QMAX_2:
+      base: uint
+      start: 32
+      end: 48
+    QMAX_3:
+      base: uint
+      start: 48
+      end: 64
+    QMAX_DOD0_0:
+      base: uint
+      start: 64
+      end: 80
+    QMAX_DOD0_1:
+      base: uint
+      start: 80
+      end: 96
+    QMAX_DOD0_2:
+      base: uint
+      start: 96
+      end: 112
+    QMAX_DOD0_3:
+      base: uint
+      start: 112
+      end: 128
+    QMAX_PASSED_Q:
+      base: uint
+      start: 128
+      end: 144
+    QMAX_TIME:
+      base: uint
+      start: 144
+      end: 160
+    TEMP_K_FACTOR:
+      base: uint
+      start: 160
+      end: 176
+    TEMP_A_FACTOR:
+      base: uint
+      start: 176
+      end: 192
+
+MAC_CB_STATUS:
+  type: command
+  address: 0x447600
+  size_bits_out: 64
+  fields_out:
+    CB_TIME_0:
+      base: uint
+      start: 0
+      end: 16
+    CB_TIME_1:
+      base: uint
+      start: 16
+      end: 32
+    CB_TIME_2:
+      base: uint
+      start: 32
+      end: 48
+    CB_TIME_3:
+      base: uint
+      start: 48
+      end: 64
+
+MAC_STATE_OF_HEALTH:
+  type: command
+  address: 0x447700
+  size_bits_out: 32
+  fields_out:
+    SOH_FCC:
+      base: uint
+      start: 0
+      end: 16
+    SOH_ENERGY:
+      base: uint
+      start: 16
+      end: 32
+
+MAC_FILTER_CAPACITY:
+  type: command
+  address: 0x447800
+  size_bits_out: 64
+  fields_out:
+    FILT_REM_CAP:
+      base: uint
+      start: 0
+      end: 16
+    FILT_REM_ENERGY:
+      base: uint
+      start: 16
+      end: 32
+    FILT_FULL_CHG_CAP:
+      base: uint
+      start: 32
+      end: 48
+    FILT_FULL_CHG_ENERGY:
+      base: uint
+      start: 48
+      end: 64
+
+MAC_ROM_MODE:
+  type: command
+  address: 0x44000F
+
+MAC_EXIT_CALIBRATION_OUTPUT_MODE:
+  type: command
+  address: 0x4480F0
+
+MAC_STOP_OUTPUT_CCADC_CAL:
+  type: command
+  address: 0x4481F0
+  allow_address_overlap: true
+
+MAC_OUTPUT_CCADC_CAL:
+  type: command
+  address: 0x4481F0
+  allow_address_overlap: true
+  size_bits_out: 192
+  fields_out:
+    REFRESH_CTR:
+      base: uint
+      start: 0
+      end: 8
+    STATUS:
+      base: uint
+      start: 8
+      end: 16
+    CURRENT:
+      base: uint
+      start: 16
+      end: 32
+    CELL_VOLTAGE_1:
+      base: uint
+      start: 32
+      end: 48
+    CELL_VOLTAGE_2:
+      base: uint
+      start: 48
+      end: 64
+    CELL_VOLTAGE_3:
+      base: uint
+      start: 64
+      end: 80
+    CELL_VOLTAGE_4:
+      base: uint
+      start: 80
+      end: 96
+    PACK_VOLTAGE:
+      base: uint
+      start: 96
+      end: 112
+    BAT_VOLTAGE:
+      base: uint
+      start: 112
+      end: 128
+    CELL_CURRENT_1:
+      base: uint
+      start: 128
+      end: 144
+    CELL_CURRENT_2:
+      base: uint
+      start: 144
+      end: 160
+    CELL_CURRENT_3:
+      base: uint
+      start: 160
+      end: 176
+    CELL_CURRENT_4:
+      base: uint
+      start: 176
+      end: 192
+
+MAC_STOP_OUTPUT_SHORTED_CCADC_CAL:
+  type: command
+  address: 0x4482F0
+  allow_address_overlap: true
+
+MAC_OUTPUT_SHORTED_CCADC_CAL:
+  type: command
+  address: 0x4482F0
+  allow_address_overlap: true
+  size_bits_out: 192
+  fields_out:
+    REFRESH_CTR:
+      base: uint
+      start: 0
+      end: 8
+    STATUS:
+      base: uint
+      start: 8
+      end: 16
+    CURRENT:
+      base: uint
+      start: 16
+      end: 32
+    CELL_VOLTAGE_1:
+      base: uint
+      start: 32
+      end: 48
+    CELL_VOLTAGE_2:
+      base: uint
+      start: 48
+      end: 64
+    CELL_VOLTAGE_3:
+      base: uint
+      start: 64
+      end: 80
+    CELL_VOLTAGE_4:
+      base: uint
+      start: 80
+      end: 96
+    PACK_VOLTAGE:
+      base: uint
+      start: 96
+      end: 112
+    BAT_VOLTAGE:
+      base: uint
+      start: 112
+      end: 128
+    CELL_CURRENT_1:
+      base: uint
+      start: 128
+      end: 144
+    CELL_CURRENT_2:
+      base: uint
+      start: 144
+      end: 160
+    CELL_CURRENT_3:
+      base: uint
+      start: 160
+      end: 176
+    CELL_CURRENT_4:
+      base: uint
+      start: 176
+      end: 192
+
+MAC_VOLTAGE_OVERRIDE:
+  type: command
+  address: 0x44B000
+  size_bits_out: 80
+  fields_out:
+    LOW_TEMP_CHARGE_VOLTAGE:
+      base: uint
+      start: 0
+      end: 16
+    STD_TEMP_LOW_CHARGE_VOLTAGE:
+      base: uint
+      start: 16
+      end: 32
+    STD_TEMP_HIGH_CHARGE_VOLTAGE:
+      base: uint
+      start: 32
+      end: 48
+    HIGH_TEMP_CHARGE_VOLTAGE:
+      base: uint
+      start: 48
+      end: 64
+    RECOMMENDED_TEMP_CHARGE_VOLTAGE:
+      base: uint
+      start: 64
+      end: 80
+
+REMAINING_CAPACITY_ALARM:
+  type: register
+  address: 0x01
+  size_bits: 16
+  reset_value: 300
+  fields:
+    REMAINING_CAPACITY_ALARM:
+      base: uint
+      start: 0
+      end: 16
+  description: This read/write word function sets a low capacity alarm threshold for the cell stack.
+
+REMAINING_TIME_ALARM:
+  type: register
+  address: 0x02
+  size_bits: 16
+  reset_value: 10
+  fields:
+    REMAINING_TIME_ALARM:
+      base: uint
+      start: 0
+      end: 16
+  description: This read/write word function sets a low remaining time-to-fully discharge alarm threshold for the cell stack.
+
+BATTERY_MODE:
+  type: register
+  address: 0x03
+  size_bits: 16
+  reset_value: 0x4000
+  fields:
+    ICC:
+      base: bool
+      access: RO
+      start: 0
+    PBS:
+      base: bool
+      access: RO
+      start: 1
+    CF:
+      base: bool
+      access: RO
+      start: 7
+    CC:
+      base: bool
+      start: 8
+    PB:
+      base: bool
+      start: 9
+    AM:
+      base: bool
+      start: 13
+    CHGM:
+      base: bool
+      start: 14
+    CAPM:
+      base: bool
+      start: 15
+
+AT_RATE:
+  type: register
+  address: 0x04
+  size_bits: 16
+  reset_value: 0
+  fields:
+    AT_RATE:
+      base: int
+      start: 0
+      end: 16
+
+AT_RATE_TIME_TO_FULL:
+  type: register
+  address: 0x05
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    AT_RATE_TIME_TO_FULL:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+AT_RATE_TIME_TO_EMPTY:
+  type: register
+  address: 0x06
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    AT_RATE_TIME_TO_EMPTY:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+AT_RATE_OK:
+  type: register
+  address: 0x07
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    AT_RATE_OK:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+TEMPERATURE:
+  type: register
+  address: 0x08
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    TEMPERATURE:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+VOLTAGE:
+  type: register
+  address: 0x09
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    VOLTAGE:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+CURRENT:
+  type: register
+  address: 0x0A
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    CURRENT:
+      base: int
+      access: RO
+      start: 0
+      end: 16
+
+AVG_CURRENT:
+  type: register
+  address: 0x0B
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    AVG_CURRENT:
+      base: int
+      access: RO
+      start: 0
+      end: 16
+
+MAX_ERROR:
+  type: register
+  address: 0x0C
+  size_bits: 8
+  reset_value: 0
+  access: RO
+  fields:
+    MAX_ERROR:
+      base: uint
+      access: RO
+      start: 0
+      end: 8
+
+RELATIVE_STATE_OF_CHARGE:
+  type: register
+  address: 0x0D
+  size_bits: 8
+  reset_value: 0
+  access: RO
+  fields:
+    RELATIVE_STATE_OF_CHARGE:
+      base: uint
+      access: RO
+      start: 0
+      end: 8
+
+ABSOLUTE_STATE_OF_CHARGE:
+  type: register
+  address: 0x0E
+  size_bits: 8
+  reset_value: 0
+  access: RO
+  fields:
+    ABSOLUTE_STATE_OF_CHARGE:
+      base: uint
+      access: RO
+      start: 0
+      end: 8
+
+REMAINING_CAPACITY:
+  type: register
+  address: 0x0F
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    REMAINING_CAPACITY:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+FULL_CHARGE_CAPACITY:
+  type: register
+  address: 0x10
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    FULL_CHARGE_CAPACITY:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+RUN_TIME_TO_EMPTY:
+  type: register
+  address: 0x11
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    RUN_TIME_TO_EMPTY:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+AVERAGE_TIME_TO_EMPTY:
+  type: register
+  address: 0x12
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    AVERAGE_TIME_TO_EMPTY:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+AVERAGE_TIME_TO_FULL:
+  type: register
+  address: 0x13
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    AVERAGE_TIME_TO_FULL:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+CHARGING_CURRENT:
+  type: register
+  address: 0x14
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    CHARGING_CURRENT:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+CHARGING_VOLTAGE:
+  type: register
+  address: 0x15
+  size_bits: 16
+  reset_value: 0
+  access: RO
+  fields:
+    CHARGING_VOLTAGE:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+BATTERY_STATUS:
+  type: register
+  address: 0x16
+  size_bits: 16
+  access: RO
+  fields:
+    EC:
+      base: uint
+      access: RO
+      start: 0
+      end: 3
+      conversion: "ErrorCode"
+    FD:
+      base: bool
+      access: RO
+      start: 4
+    FC:
+      base: bool
+      access: RO
+      start: 5
+    DSG:
+      base: bool
+      access: RO
+      start: 6
+    INIT:
+      base: bool
+      access: RO
+      start: 7
+    RTA:
+      base: bool
+      access: RO
+      start: 8
+    RCA:
+      base: bool
+      access: RO
+      start: 9
+    TDA:
+      base: bool
+      access: RO
+      start: 11
+    OTA:
+      base: bool
+      access: RO
+      start: 12
+    TCA:
+      base: bool
+      access: RO
+      start: 14
+    OCA:
+      base: bool
+      access: RO
+      start: 15
+
+CYCLE_COUNT:
+  type: register
+  address: 0x17
+  size_bits: 16
+  access: RW
+  fields:
+    CYCLE_COUNT:
+      base: uint
+      access: RW
+      start: 0
+      end: 16
+
+DESIGN_CAPACITY:
+  type: register
+  address: 0x18
+  size_bits: 16
+  access: RW
+  fields:
+    DESIGN_CAPACITY:
+      base: uint
+      access: RW
+      start: 0
+      end: 16
+
+DESIGN_VOLTAGE:
+  type: register
+  address: 0x19
+  size_bits: 16
+  access: RW
+  fields:
+    DESIGN_VOLTAGE:
+      base: uint
+      access: RW
+      start: 0
+      end: 16
+
+SPECIFICATION_INFO:
+  type: register
+  address: 0x1A
+  size_bits: 16
+  access: RW
+  fields:
+    REVISION:
+      base: uint
+      start: 0
+      end: 4
+    VERSION:
+      base: uint
+      start: 4
+      end: 8
+    VSCALE:
+      base: uint
+      access: RO
+      start: 8
+      end: 12
+    IPSCALE:
+      base: uint
+      access: RO
+      start: 12
+      end: 16
+
+MANUFACTURE_DATE:
+  type: register
+  address: 0x1B
+  size_bits: 16
+  access: RW
+  fields:
+    MANUFACTURE_DATE:
+      base: uint
+      access: RW
+      start: 0
+      end: 16
+
+SERIAL_NUMBER:
+  type: register
+  address: 0x1C
+  size_bits: 16
+  reset_value: 0x0001
+  access: RW
+  fields:
+    SERIAL_NUMBER:
+      base: uint
+      access: RW
+      start: 0
+      end: 16
+
+MANUFACTURE_NAME:
+  type: buffer
+  address: 0x20
+  access: RO
+
+DEVICE_NAME:
+  type: buffer
+  address: 0x21
+  access: RO
+
+DEVICE_CHEMISTRY:
+  type: buffer
+  address: 0x22
+  access: RO
+
+MANUFACTURER_DATA:
+  type: buffer
+  address: 0x23
+  access: RO
+
+AUTHENTICATE:
+  type: buffer
+  address: 0x2F
+  access: RW
+
+CELL_VOLTAGE_4:
+  type: register
+  address: 0x3C
+  size_bits: 16
+  access: RO
+  fields:
+    CELL_VOLTAGE_4:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+CELL_VOLTAGE_3:
+  type: register
+  address: 0x3D
+  size_bits: 16
+  access: RO
+  fields:
+    CELL_VOLTAGE_3:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+CELL_VOLTAGE_2:
+  type: register
+  address: 0x3E
+  size_bits: 16
+  access: RO
+  fields:
+    CELL_VOLTAGE_2:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+CELL_VOLTAGE_1:
+  type: register
+  address: 0x3F
+  size_bits: 16
+  access: RO
+  fields:
+    CELL_VOLTAGE_1:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+
+BTP_DISCHARGE_SET:
+  type: register
+  address: 0x4A
+  size_bits: 16
+  reset_value: 150
+  fields:
+    BTP_DISCHARGE_SET:
+      base: int
+      start: 0
+      end: 16
+
+BTP_CHARGE_SET:
+  type: register
+  address: 0x4B
+  size_bits: 16
+  reset_value: 175
+  fields:
+    BTP_CHARGE_SET:
+      base: int
+      start: 0
+      end: 16
+
+STATE_OF_HEALTH_SOH:
+  type: register
+  address: 0x4F
+  size_bits: 16
+  access: RO
+  fields:
+    STATE_OF_HEALTH_SOH:
+      base: int
+      access: RO
+      start: 0
+      end: 16
+
+SAFETY_ALERT:
+  type: register
+  address: 0x50
+  size_bits: 32
+  access: RO
+  fields:
+    CUV:
+      base: bool
+      access: RO
+      start: 0
+    COV:
+      base: bool
+      access: RO
+      start: 1
+    OCC1:
+      base: bool
+      access: RO
+      start: 2
+    OCC2:
+      base: bool
+      access: RO
+      start: 3
+    OCD1:
+      base: bool
+      access: RO
+      start: 4
+    OCD2:
+      base: bool
+      access: RO
+      start: 5
+    AOLDL:
+      base: bool
+      access: RO
+      start: 7
+    ASCCL:
+      base: bool
+      access: RO
+      start: 9
+    ASCDL:
+      base: bool
+      access: RO
+      start: 11
+    OTC:
+      base: bool
+      access: RO
+      start: 12
+    OTD:
+      base: bool
+      access: RO
+      start: 13
+    CUVC:
+      base: bool
+      access: RO
+      start: 14
+    OTF:
+      base: bool
+      access: RO
+      start: 16
+    PTO:
+      base: bool
+      access: RO
+      start: 18
+    PTOS:
+      base: bool
+      access: RO
+      start: 19
+    CTO:
+      base: bool
+      access: RO
+      start: 20
+    CTOS:
+      base: bool
+      access: RO
+      start: 21
+    OC:
+      base: bool
+      access: RO
+      start: 22
+    CHGC:
+      base: bool
+      access: RO
+      start: 23
+    CHGV:
+      base: bool
+      access: RO
+      start: 24
+    PCHGC:
+      base: bool
+      access: RO
+      start: 25
+    UTC:
+      base: bool
+      access: RO
+      start: 26
+    UTD:
+      base: bool
+      access: RO
+      start: 27
+
+SAFETY_STATUS:
+  type: register
+  address: 0x51
+  access: RO
+  size_bits: 32
+  fields:
+    CUV:
+      base: bool
+      access: RO
+      start: 0
+    COV:
+      base: bool
+      access: RO
+      start: 1
+    OCC1:
+      base: bool
+      access: RO
+      start: 2
+    OCC2:
+      base: bool
+      access: RO
+      start: 3
+    OCD1:
+      base: bool
+      access: RO
+      start: 4
+    OCD2:
+      base: bool
+      access: RO
+      start: 5
+    AOLD:
+      base: bool
+      access: RO
+      start: 6
+    AOLDL:
+      base: bool
+      access: RO
+      start: 7
+    ASCC:
+      base: bool
+      access: RO
+      start: 8
+    ASCCL:
+      base: bool
+      access: RO
+      start: 9
+    ASCD:
+      base: bool
+      access: RO
+      start: 10
+    ASCDL:
+      base: bool
+      access: RO
+      start: 11
+    OTC:
+      base: bool
+      access: RO
+      start: 12
+    OTD:
+      base: bool
+      access: RO
+      start: 13
+    CUVC:
+      base: bool
+      access: RO
+      start: 14
+    OTF:
+      base: bool
+      access: RO
+      start: 16
+    PTO:
+      base: bool
+      access: RO
+      start: 18
+    PTOS:
+      base: bool
+      access: RO
+      start: 19
+    CTO:
+      base: bool
+      access: RO
+      start: 20
+    OC:
+      base: bool
+      access: RO
+      start: 22
+    CHGC:
+      base: bool
+      access: RO
+      start: 23
+    CHGV:
+      base: bool
+      access: RO
+      start: 24
+    PCHGC:
+      base: bool
+      access: RO
+      start: 25
+    UTC:
+      base: bool
+      access: RO
+      start: 26
+    UTD:
+      base: bool
+      access: RO
+      start: 27
+
+PF_ALERT:
+  type: register
+  address: 0x52
+  size_bits: 32
+  access: RO
+  fields:
+    SUV:
+      base: bool
+      access: RO
+      start: 0
+    SOV:
+      base: bool
+      access: RO
+      start: 1
+    SOCC:
+      base: bool
+      access: RO
+      start: 2
+    SOCD:
+      base: bool
+      access: RO
+      start: 3
+    SOT:
+      base: bool
+      access: RO
+      start: 4
+    SOTF:
+      base: bool
+      access: RO
+      start: 6
+    QIM:
+      base: bool
+      access: RO
+      start: 7
+    CB:
+      base: bool
+      access: RO
+      start: 8
+    IMP:
+      base: bool
+      access: RO
+      start: 9
+    CD:
+      base: bool
+      access: RO
+      start: 10
+    VIMR:
+      base: bool
+      access: RO
+      start: 11
+    VIMA:
+      base: bool
+      access: RO
+      start: 12
+    CFETF:
+      base: bool
+      access: RO
+      start: 16
+    DFETF:
+      base: bool
+      access: RO
+      start: 17
+    FUSE:
+      base: bool
+      access: RO
+      start: 19
+    AFER:
+      base: bool
+      access: RO
+      start: 20
+    AFEC:
+      base: bool
+      access: RO
+      start: 21
+    SECOND_LVL:
+      base: bool
+      access: RO
+      start: 22
+    OPNC:
+      base: bool
+      access: RO
+      start: 25
+    TS1:
+      base: bool
+      access: RO
+      start: 28
+    TS2:
+      base: bool
+      access: RO
+      start: 29
+    TS3:
+      base: bool
+      access: RO
+      start: 30
+    TS4:
+      base: bool
+      access: RO
+      start: 31
+
+PF_STATUS:
+  type: register
+  address: 0x53
+  access: RO
+  size_bits: 32
+  fields:
+    SUV:
+      base: bool
+      access: RO
+      start: 0
+    SOV:
+      base: bool
+      access: RO
+      start: 1
+    SOCC:
+      base: bool
+      access: RO
+      start: 2
+    SOCD:
+      base: bool
+      access: RO
+      start: 3
+    SOT:
+      base: bool
+      access: RO
+      start: 4
+    SOTF:
+      base: bool
+      access: RO
+      start: 6
+    QIM:
+      base: bool
+      access: RO
+      start: 7
+    CB:
+      base: bool
+      access: RO
+      start: 8
+    IMP:
+      base: bool
+      access: RO
+      start: 9
+    CD:
+      base: bool
+      access: RO
+      start: 10
+    VIMR:
+      base: bool
+      access: RO
+      start: 11
+    VIMA:
+      base: bool
+      access: RO
+      start: 12
+    CFETF:
+      base: bool
+      access: RO
+      start: 16
+    DFETF:
+      base: bool
+      access: RO
+      start: 17
+    FUSE:
+      base: bool
+      access: RO
+      start: 19
+    AFER:
+      base: bool
+      access: RO
+      start: 20
+    AFEC:
+      base: bool
+      access: RO
+      start: 21
+    SECOND_LVL:
+      base: bool
+      access: RO
+      start: 22
+    PTC:
+      base: bool
+      access: RO
+      start: 23
+    IFC:
+      base: bool
+      access: RO
+      start: 24
+    OPNCELL:
+      base: bool
+      access: RO
+      start: 25
+    DFW:
+      base: bool
+      access: RO
+      start: 26
+    TS1:
+      base: bool
+      access: RO
+      start: 28
+    TS2:
+      base: bool
+      access: RO
+      start: 29
+    TS3:
+      base: bool
+      access: RO
+      start: 30
+    TS4:
+      base: bool
+      access: RO
+      start: 31
+
+OPERATION_STATUS:
+  type: register
+  address: 0x54
+  size_bits: 32
+  access: RO
+  fields:
+    PRES:
+      base: bool
+      access: RO
+      start: 0
+    DSG:
+      base: bool
+      access: RO
+      start: 1
+    CHG:
+      base: bool
+      access: RO
+      start: 2
+    PCHG:
+      base: bool
+      access: RO
+      start: 3
+    FUSE:
+      base: bool
+      access: RO
+      start: 5
+    BTP_INT:
+      base: bool
+      access: RO
+      start: 7
+    SEC:
+      base: uint
+      access: RO
+      start: 8
+      end: 10
+      conversion:
+        name: "SecurityMode"
+        Reserved: 0
+        FullAccess: 1
+        UnSealed: 2
+        Sealed: 3
+    SDV:
+      base: bool
+      access: RO
+      start: 10
+    SS:
+      base: bool
+      access: RO
+      start: 11
+    PF:
+      base: bool
+      access: RO
+      start: 12
+    XDSG:
+      base: bool
+      access: RO
+      start: 13
+    XCHG:
+      base: bool
+      access: RO
+      start: 14
+    SLEEP:
+      base: bool
+      access: RO
+      start: 15
+    SDM:
+      base: bool
+      access: RO
+      start: 16
+    LED:
+      base: bool
+      access: RO
+      start: 17
+    AUTH:
+      base: bool
+      access: RO
+      start: 18
+    AUTOCALM:
+      base: bool
+      access: RO
+      start: 19
+    CAL:
+      base: bool
+      access: RO
+      start: 20
+    CAL_OFFSET:
+      base: bool
+      access: RO
+      start: 21
+    XL:
+      base: bool
+      access: RO
+      start: 22
+    SLEEPM:
+      base: bool
+      access: RO
+      start: 23
+    INIT:
+      base: bool
+      access: RO
+      start: 24
+    SMBLCAL:
+      base: bool
+      access: RO
+      start: 25
+    SLPAD:
+      base: bool
+      access: RO
+      start: 26
+    SLPCC:
+      base: bool
+      access: RO
+      start: 27
+    CB:
+      base: bool
+      access: RO
+      start: 28
+    EMSHUT:
+      base: bool
+      access: RO
+      start: 29
+
+CHARGING_STATUS:
+  type: register
+  address: 0x55
+  size_bits: 32
+  access: RO
+  fields:
+    UT:
+      base: bool
+      access: RO
+      start: 0
+    LT:
+      base: bool
+      access: RO
+      start: 1
+    STL:
+      base: bool
+      access: RO
+      start: 2
+    RT:
+      base: bool
+      access: RO
+      start: 3
+    STH:
+      base: bool
+      access: RO
+      start: 4
+    HT:
+      base: bool
+      access: RO
+      start: 5
+    OT:
+      base: bool
+      access: RO
+      start: 6
+    PV:
+      base: bool
+      access: RO
+      start: 8
+    LV:
+      base: bool
+      access: RO
+      start: 9
+    MV:
+      base: bool
+      access: RO
+      start: 10
+    HV:
+      base: bool
+      access: RO
+      start: 11
+    CHG_IN:
+      base: bool
+      access: RO
+      start: 12
+    MCHG:
+      base: bool
+      access: RO
+      start: 13
+    VCT:
+      base: bool
+      access: RO
+      start: 14
+    CCR:
+      base: bool
+      access: RO
+      start: 15
+    CVR:
+      base: bool
+      access: RO
+      start: 16
+    CCC:
+      base: bool
+      access: RO
+      start: 17
+
+GAUGING_STATUS:
+  type: register
+  address: 0x56
+  access: RO
+  size_bits: 32
+  fields:
+    FD:
+      base: bool
+      access: RO
+      start: 0
+    FC:
+      base: bool
+      access: RO
+      start: 1
+    TD:
+      base: bool
+      access: RO
+      start: 2
+    TC:
+      base: bool
+      access: RO
+      start: 3
+    BAL_EN:
+      base: bool
+      access: RO
+      start: 4
+    EDV:
+      base: bool
+      access: RO
+      start: 5
+    DSG:
+      base: bool
+      access: RO
+      start: 6
+    CF:
+      base: bool
+      access: RO
+      start: 7
+    REST:
+      base: bool
+      access: RO
+      start: 8
+    R_DIS:
+      base: bool
+      access: RO
+      start: 10
+    VOK:
+      base: bool
+      access: RO
+      start: 11
+    QEN:
+      base: bool
+      access: RO
+      start: 12
+    SLPQMAX:
+      base: bool
+      access: RO
+      start: 13
+    NSFM:
+      base: bool
+      access: RO
+      start: 15
+    VDQ:
+      base: bool
+      access: RO
+      start: 16
+    QMAX:
+      base: bool
+      access: RO
+      start: 17
+    RX:
+      base: bool
+      access: RO
+      start: 18
+    LDMD:
+      base: bool
+      access: RO
+      start: 19
+    OCVFR:
+      base: bool
+      access: RO
+      start: 20
+
+MANUFACTURING_STATUS:
+  type: register
+  address: 0x57
+  size_bits: 16
+  access: RO
+  fields:
+    PCHG_EN:
+      base: bool
+      access: RO
+      start: 0
+    CHG_EN:
+      base: bool
+      access: RO
+      start: 1
+    DSG_EN:
+      base: bool
+      access: RO
+      start: 2
+    GAUGE_EN:
+      base: bool
+      access: RO
+      start: 3
+    FET_EN:
+      base: bool
+      access: RO
+      start: 4
+    LF_EN:
+      base: bool
+      access: RO
+      start: 5
+    PF_EN:
+      base: bool
+      access: RO
+      start: 6
+    BBR_EN:
+      base: bool
+      access: RO
+      start: 7
+    FUSE_EN:
+      base: bool
+      access: RO
+      start: 8
+    LED_EN:
+      base: bool
+      access: RO
+      start: 9
+    LT_TEST:
+      base: bool
+      access: RO
+      start: 14
+    CAL_TEST:
+      base: bool
+      access: RO
+      start: 15
+
+AFE_REG:
+  type: register
+  address: 0x58
+  size_bits: 168
+  access: RO
+  fields:
+    AFE_INT_STATUS:
+      base: uint
+      access: RO
+      start: 0
+      end: 8
+    AFE_FET_STATUS:
+      base: uint
+      access: RO
+      start: 8
+      end: 16
+    AFE_RXIN:
+      base: uint
+      access: RO
+      start: 16
+      end: 24
+    AFE_LATCH_STATUS:
+      base: uint
+      access: RO
+      start: 24
+      end: 32
+    AFE_INT_EN:
+      base: uint
+      access: RO
+      start: 32
+      end: 40
+    AFE_CTRL:
+      base: uint
+      access: RO
+      start: 40
+      end: 48
+    AFE_RXIEN:
+      base: uint
+      access: RO
+      start: 48
+      end: 56
+    AFE_RLOUT:
+      base: uint
+      access: RO
+      start: 56
+      end: 64
+    AFE_RHOUT:
+      base: uint
+      access: RO
+      start: 64
+      end: 72
+    AFE_RHINT:
+      base: uint
+      access: RO
+      start: 72
+      end: 80
+    AFE_CELL_BALANCE:
+      base: uint
+      access: RO
+      start: 80
+      end: 88
+    AFE_ADC_CC_CTRL:
+      base: uint
+      access: RO
+      start: 88
+      end: 96
+    AFE_ADC_MUX_CTRL:
+      base: uint
+      access: RO
+      start: 96
+      end: 104
+    AFE_LED_CTRL:
+      base: uint
+      access: RO
+      start: 104
+      end: 112
+    AFE_HW_CTRL:
+      base: uint
+      access: RO
+      start: 112
+      end: 120
+    AFE_TMR_CTRL:
+      base: uint
+      access: RO
+      start: 120
+      end: 128
+    AFE_PROTECTION:
+      base: uint
+      access: RO
+      start: 128
+      end: 136
+    AFE_OCD:
+      base: uint
+      access: RO
+      start: 136
+      end: 144
+    AFE_SCC:
+      base: uint
+      access: RO
+      start: 144
+      end: 152
+    AFE_SCD1:
+      base: uint
+      access: RO
+      start: 152
+      end: 160
+    AFE_SCD2:
+      base: uint
+      access: RO
+      start: 160
+      end: 168
+
+TURBO_POWER:
+  type: register
+  address: 0x59
+  size_bits: 16
+  access: RW
+  fields:
+    TURBO_POWER:
+      base: uint
+      access: RW
+      start: 0
+      end: 16
+
+TURBO_FINAL:
+  type: register
+  address: 0x5A
+  size_bits: 16
+  access: RW
+  fields:
+    TURBO_FINAL:
+      base: uint
+      access: RW
+      start: 0
+      end: 16
+
+TURBO_PACK_R:
+  type: register
+  address: 0x5B
+  size_bits: 16
+  access: RW
+  fields:
+    TURBO_PACK_R:
+      base: uint
+      access: RW
+      start: 0
+      end: 16
+
+TURBO_SYS_R:
+  type: register
+  address: 0x5C
+  size_bits: 16
+  access: RW
+  fields:
+    TURBO_SYS_R:
+      base: uint
+      access: RW
+      start: 0
+      end: 16
+
+TURBO_EDV:
+  type: register
+  address: 0x5D
+  size_bits: 16
+  access: RW
+  fields:
+    TURBO_EDV:
+      base: uint
+      access: RW
+      start: 0
+      end: 16
+
+TURBO_CURRENT:
+  type: register
+  address: 0x5E
+  size_bits: 16
+  access: RW
+  fields:
+    TURBO_CURRENT:
+      base: uint
+      access: RW
+      start: 0
+      end: 16
+
+LIFETIME_DATA_BLOCK_1:
+  type: register
+  address: 0x60
+  size_bits: 256
+  access: RO
+  fields:
+    CELL_1_MAX_V:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+    CELL_2_MAX_V:
+      base: uint
+      access: RO
+      start: 16
+      end: 32
+    CELL_3_MAX_V:
+      base: uint
+      access: RO
+      start: 32
+      end: 48
+    CELL_4_MAX_V:
+      base: uint
+      access: RO
+      start: 48
+      end: 64
+    CELL_1_MIN_V:
+      base: uint
+      access: RO
+      start: 64
+      end: 80
+    CELL_2_MIN_V:
+      base: uint
+      access: RO
+      start: 80
+      end: 96
+    CELL_3_MIN_V:
+      base: uint
+      access: RO
+      start: 96
+      end: 112
+    CELL_4_MIN_V:
+      base: uint
+      access: RO
+      start: 112
+      end: 128
+    MAX_DELTA_CELL_V:
+      base: uint
+      access: RO
+      start: 128
+      end: 144
+    MAX_CHARGE_A:
+      base: uint
+      access: RO
+      start: 144
+      end: 160
+    MAX_DISCHARGE_A:
+      base: uint
+      access: RO
+      start: 160
+      end: 176
+    MAX_AVG_DISCHARGE_A:
+      base: uint
+      access: RO
+      start: 176
+      end: 192
+    MAX_AVG_DISCHARGE_PWR:
+      base: uint
+      access: RO
+      start: 192
+      end: 208
+    MAX_TEMP_CELL:
+      base: uint
+      access: RO
+      start: 208
+      end: 216
+    MIN_TEMP_CELL:
+      base: uint
+      access: RO
+      start: 216
+      end: 224
+    MAX_DELTA_CELL_TEMP:
+      base: uint
+      access: RO
+      start: 224
+      end: 232
+    MAX_TEMP_INT_SENSOR:
+      base: uint
+      access: RO
+      start: 232
+      end: 240
+    MIN_TEMP_INT_SENSOR:
+      base: uint
+      access: RO
+      start: 240
+      end: 248
+    MAX_TEMP_FET:
+      base: uint
+      access: RO
+      start: 248
+      end: 256
+
+LIFETIME_DATA_BLOCK_2:
+  type: register
+  address: 0x61
+  access: RO
+  size_bits: 64
+  fields:
+    NUM_SHUTDOWNS:
+      base: uint
+      access: RO
+      start: 0
+      end: 8
+    NUM_PART_RESETS:
+      base: uint
+      access: RO
+      start: 8
+      end: 16
+    NUM_FULL_RESETS:
+      base: uint
+      access: RO
+      start: 16
+      end: 24
+    NUM_WDT_RESETS:
+      base: uint
+      access: RO
+      start: 24
+      end: 32
+    CB_TIME_CELL_1:
+      base: uint
+      access: RO
+      start: 32
+      end: 40
+    CB_TIME_CELL_2:
+      base: uint
+      access: RO
+      start: 40
+      end: 48
+    CB_TIME_CELL_3:
+      base: uint
+      access: RO
+      start: 48
+      end: 56
+    CB_TIME_CELL_4:
+      base: uint
+      access: RO
+      start: 56
+      end: 64
+
+LIFETIME_DATA_BLOCK_3:
+  type: register
+  address: 0x62
+  access: RO
+  size_bits: 128
+  fields:
+    TOTAL_FW_RUNTIME:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+    TIME_SPENT_IN_UT:
+      base: uint
+      access: RO
+      start: 16
+      end: 32
+    TIME_SPENT_IN_LT:
+      base: uint
+      access: RO
+      start: 32
+      end: 48
+    TIME_SPENT_IN_STL:
+      base: uint
+      access: RO
+      start: 48
+      end: 64
+    TIME_SPENT_IN_RT:
+      base: uint
+      access: RO
+      start: 64
+      end: 80
+    TIME_SPENT_IN_STH:
+      base: uint
+      access: RO
+      start: 80
+      end: 96
+    TIME_SPENT_IN_HT:
+      base: uint
+      access: RO
+      start: 96
+      end: 112
+    TIME_SPENT_IN_OT:
+      base: uint
+      access: RO
+      start: 112
+      end: 128
+
+LIFETIME_DATA_BLOCK_4:
+  type: register
+  address: 0x63
+  size_bits: 256
+  access: RO
+  fields:
+    NUM_COV_EVENTS:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+    LAST_COV_EVENT:
+      base: uint
+      access: RO
+      start: 16
+      end: 32
+    NUM_CUV_EVENTS:
+      base: uint
+      access: RO
+      start: 32
+      end: 48
+    LAST_CUV_EVENT:
+      base: uint
+      access: RO
+      start: 48
+      end: 64
+    NUM_OCD1_EVENT:
+      base: uint
+      access: RO
+      start: 64
+      end: 80
+    LAST_OCD1_EVENT:
+      base: uint
+      access: RO
+      start: 80
+      end: 96
+    NUM_OCD2_EVENTS:
+      base: uint
+      access: RO
+      start: 96
+      end: 112
+    LAST_OCD2_EVENT:
+      base: uint
+      access: RO
+      start: 112
+      end: 128
+    NUM_OCC1_EVENTS:
+      base: uint
+      access: RO
+      start: 128
+      end: 144
+    LAST_OCC1_EVENT:
+      base: uint
+      access: RO
+      start: 144
+      end: 160
+    NUM_OCC2_EVENTS:
+      base: uint
+      access: RO
+      start: 160
+      end: 176
+    LAST_OCC2_EVENT:
+      base: uint
+      access: RO
+      start: 176
+      end: 192
+    NUM_AOLD_EVENTS:
+      base: uint
+      access: RO
+      start: 192
+      end: 208
+    LAST_AOLD_EVENT:
+      base: uint
+      access: RO
+      start: 208
+      end: 224
+    NUM_ASCD_EVENTS:
+      base: uint
+      access: RO
+      start: 224
+      end: 240
+    LAST_ASCD_EVENT:
+      base: uint
+      access: RO
+      start: 240
+      end: 256
+
+LIFETIME_DATA_BLOCK_5:
+  type: register
+  address: 0x64
+  size_bits: 256
+  access: RO
+  fields:
+    NUM_ASCC_EVENTS:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+    LAST_ASCC_EVENT:
+      base: uint
+      access: RO
+      start: 16
+      end: 32
+    NUM_OTC_EVENTS:
+      base: uint
+      access: RO
+      start: 32
+      end: 48
+    LAST_OTC_EVENT:
+      base: uint
+      access: RO
+      start: 48
+      end: 64
+    NUM_OTD_EVENT:
+      base: uint
+      access: RO
+      start: 64
+      end: 80
+    LAST_OTD_EVENT:
+      base: uint
+      access: RO
+      start: 80
+      end: 96
+    NUM_OTF_EVENTS:
+      base: uint
+      access: RO
+      start: 96
+      end: 112
+    LAST_OTF_EVENT:
+      base: uint
+      access: RO
+      start: 112
+      end: 128
+    NUM_VALID_CHG_TERM:
+      base: uint
+      access: RO
+      start: 128
+      end: 144
+    LAST_VALID_CHG_TERM:
+      base: uint
+      access: RO
+      start: 144
+      end: 160
+    NUM_QMAX_UPDATES:
+      base: uint
+      access: RO
+      start: 160
+      end: 176
+    LAST_QMAX_UPDATE:
+      base: uint
+      access: RO
+      start: 176
+      end: 192
+    NUM_RA_UPDATES:
+      base: uint
+      access: RO
+      start: 192
+      end: 208
+    LAST_RA_UPDATE:
+      base: uint
+      access: RO
+      start: 208
+      end: 224
+    NUM_RA_DISABLE:
+      base: uint
+      access: RO
+      start: 224
+      end: 240
+    LAST_RA_DISABLE:
+      base: uint
+      access: RO
+      start: 240
+      end: 256
+
+MANUFACTURE_INFO:
+  type: buffer
+  address: 0x70
+  access: RW
+
+DA_STATUS_1:
+  type: register
+  address: 0x71
+  size_bits: 256
+  access: RO
+  fields:
+    CELL_VOLTAGE_1:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+    CELL_VOLTAGE_2:
+      base: uint
+      access: RO
+      start: 16
+      end: 32
+    CELL_VOLTAGE_3:
+      base: uint
+      access: RO
+      start: 32
+      end: 48
+    CELL_VOLTAGE_4:
+      base: uint
+      access: RO
+      start: 48
+      end: 64
+    BAT_VOLTAGE:
+      base: uint
+      access: RO
+      start: 64
+      end: 80
+    PACK_VOLTAGE:
+      base: uint
+      access: RO
+      start: 80
+      end: 96
+    CELL_CURRENT_1:
+      base: uint
+      access: RO
+      start: 96
+      end: 112
+    CELL_CURRENT_2:
+      base: uint
+      access: RO
+      start: 112
+      end: 128
+    CELL_CURRENT_3:
+      base: uint
+      access: RO
+      start: 128
+      end: 144
+    CELL_CURRENT_4:
+      base: uint
+      access: RO
+      start: 144
+      end: 160
+    CELL_PWR_1:
+      base: uint
+      access: RO
+      start: 160
+      end: 176
+    CELL_PWR_2:
+      base: uint
+      access: RO
+      start: 176
+      end: 192
+    CELL_PWR_3:
+      base: uint
+      access: RO
+      start: 192
+      end: 208
+    CELL_PWR_4:
+      base: uint
+      access: RO
+      start: 208
+      end: 224
+    TOTAL_PWR:
+      base: uint
+      access: RO
+      start: 224
+      end: 240
+    AVG_PWR:
+      base: uint
+      access: RO
+      start: 240
+      end: 256
+
+DA_STATUS_2:
+  type: register
+  address: 0x72
+  size_bits: 112
+  access: RO
+  fields:
+    INT_TEMP:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+    TS1_TEMP:
+      base: uint
+      access: RO
+      start: 16
+      end: 32
+    TS2_TEMP:
+      base: uint
+      access: RO
+      start: 32
+      end: 48
+    TS3_TEMP:
+      base: uint
+      access: RO
+      start: 48
+      end: 64
+    TS4_TEMP:
+      base: uint
+      access: RO
+      start: 64
+      end: 80
+    CELL_TEMP:
+      base: uint
+      access: RO
+      start: 80
+      end: 96
+    FET_TEMP:
+      base: uint
+      access: RO
+      start: 96
+      end: 112
+
+GAUGE_STATUS_1:
+  type: register
+  address: 0x73
+  size_bits: 256
+  access: RO
+  fields:
+    TRUE_REM_Q:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+    TRUE_REM_E:
+      base: uint
+      access: RO
+      start: 16
+      end: 32
+    INITIAL_Q:
+      base: uint
+      access: RO
+      start: 32
+      end: 48
+    INITIAL_E:
+      base: uint
+      access: RO
+      start: 48
+      end: 64
+    TRUE_FCC_Q:
+      base: uint
+      access: RO
+      start: 64
+      end: 80
+    TRUE_FCC_E:
+      base: uint
+      access: RO
+      start: 80
+      end: 96
+    T_SIM:
+      base: uint
+      access: RO
+      start: 96
+      end: 112
+    T_AMBIENT:
+      base: uint
+      access: RO
+      start: 112
+      end: 128
+    RA_SCALE_0:
+      base: uint
+      access: RO
+      start: 128
+      end: 144
+    RA_SCALE_1:
+      base: uint
+      access: RO
+      start: 144
+      end: 160
+    RA_SCALE_2:
+      base: uint
+      access: RO
+      start: 160
+      end: 176
+    RA_SCALE_3:
+      base: uint
+      access: RO
+      start: 176
+      end: 192
+    COMP_RES_0:
+      base: uint
+      access: RO
+      start: 192
+      end: 208
+    COMP_RES_1:
+      base: uint
+      access: RO
+      start: 208
+      end: 224
+    COMP_RES_2:
+      base: uint
+      access: RO
+      start: 224
+      end: 240
+    COMP_RES_3:
+      base: uint
+      access: RO
+      start: 240
+      end: 256
+
+GAUGE_STATUS_2:
+  type: register
+  address: 0x74
+  size_bits: 256
+  fields:
+    PACK_GRID:
+      base: uint
+      access: RO
+      start: 0
+      end: 8
+    Q_MAX_STATUS:
+      base: uint
+      access: RO
+      start: 8
+      end: 10
+      conversion:
+        name: "QMaxStatus"
+        BattOK: 0
+        QMaxUpdated: 1
+        QMaxRTableUpdated: 2
+        Reserved: 3
+    ITEN:
+      base: bool
+      access: RO
+      start: 10
+    QMAX_FIELD_UPDATED:
+      base: bool
+      access: RO
+      start: 11
+    CELL_GRID_0:
+      base: uint
+      access: RO
+      start: 16
+      end: 24
+    CELL_GRID_1:
+      base: uint
+      access: RO
+      start: 24
+      end: 32
+    CELL_GRID_2:
+      base: uint
+      access: RO
+      start: 32
+      end: 40
+    CELL_GRID_3:
+      base: uint
+      access: RO
+      start: 40
+      end: 48
+    STATE_TIME:
+      base: uint
+      access: RO
+      start: 48
+      end: 80
+    DOD0_0:
+      base: uint
+      start: 80
+      end: 96
+    DOD0_1:
+      base: uint
+      access: RO
+      start: 96
+      end: 112
+    DOD0_2:
+      base: uint
+      access: RO
+      start: 112
+      end: 128
+    DOD0_3:
+      base: uint
+      access: RO
+      start: 128
+      end: 144
+    DOD0_PASSED_Q:
+      base: uint
+      access: RO
+      start: 144
+      end: 160
+    DOD0_PASSED_E:
+      base: uint
+      access: RO
+      start: 160
+      end: 176
+    DOD0_TIME:
+      base: uint
+      access: RO
+      start: 176
+      end: 192
+    DODEOC_0:
+      base: uint
+      access: RO
+      start: 192
+      end: 208
+    DODEOC_1:
+      base: uint
+      access: RO
+      start: 208
+      end: 224
+    DODEOC_2:
+      base: uint
+      access: RO
+      start: 224
+      end: 240
+    DODEOC_3:
+      base: uint
+      access: RO
+      start: 240
+      end: 256
+
+GAUGE_STATUS_3:
+  type: register
+  address: 0x75
+  size_bits: 192
+  access: RO
+  fields:
+    QMAX_0:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+    QMAX_1:
+      base: uint
+      access: RO
+      start: 16
+      end: 32
+    QMAX_2:
+      base: uint
+      access: RO
+      start: 32
+      end: 48
+    QMAX_3:
+      base: uint
+      access: RO
+      start: 48
+      end: 64
+    QMAX_DOD0_0:
+      base: uint
+      access: RO
+      start: 64
+      end: 80
+    QMAX_DOD0_1:
+      base: uint
+      access: RO
+      start: 80
+      end: 96
+    QMAX_DOD0_2:
+      base: uint
+      access: RO
+      start: 96
+      end: 112
+    QMAX_DOD0_3:
+      base: uint
+      access: RO
+      start: 112
+      end: 128
+    QMAX_PASSED_Q:
+      base: uint
+      access: RO
+      start: 128
+      end: 144
+    QMAX_TIME:
+      base: uint
+      access: RO
+      start: 144
+      end: 160
+    TEMP_K_FACTOR:
+      base: uint
+      access: RO
+      start: 160
+      end: 176
+    TEMP_A_FACTOR:
+      base: uint
+      access: RO
+      start: 176
+      end: 192
+
+CB_STATUS:
+  type: register
+  address: 0x76
+  size_bits: 64
+  access: RO
+  fields:
+    CB_TIME_0:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+    CB_TIME_1:
+      base: uint
+      access: RO
+      start: 16
+      end: 32
+    CB_TIME_2:
+      base: uint
+      access: RO
+      start: 32
+      end: 48
+    CB_TIME_3:
+      base: uint
+      access: RO
+      start: 48
+      end: 64
+
+STATE_OF_HEALTH:
+  type: register
+  address: 0x77
+  size_bits: 32
+  access: RO
+  fields:
+    SOH_FCC:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+    SOH_ENERGY:
+      base: uint
+      access: RO
+      start: 16
+      end: 32
+
+FILTER_CAPACITY:
+  type: register
+  address: 0x78
+  size_bits: 64
+  access: RO
+  fields:
+    FILT_REM_CAP:
+      base: uint
+      access: RO
+      start: 0
+      end: 16
+    FILT_REM_ENERGY:
+      base: uint
+      access: RO
+      start: 16
+      end: 32
+    FILT_FULL_CHG_CAP:
+      base: uint
+      access: RO
+      start: 32
+      end: 48
+    FILT_FULL_CHG_ENERGY:
+      base: uint
+      access: RO
+      start: 48
+      end: 64

--- a/device_R3.yaml
+++ b/device_R3.yaml
@@ -888,7 +888,7 @@ NO_LOAD_REM_CAP:
 MAC_LIFETIME_DATA_BLOCK_1:
   type: command
   address: 0x446000
-  size_bits_out: 208
+  size_bits_out: 256
   fields_out:
     CELL_1_MAX_V:
       base: uint
@@ -942,19 +942,51 @@ MAC_LIFETIME_DATA_BLOCK_1:
       base: uint
       start: 192
       end: 208
+    MAX_TEMP_CELL:
+      base: uint
+      start: 208
+      end: 216
+    MIN_TEMP_CELL:
+      base: uint
+      start: 216
+      end: 224
+    MAX_DELTA_CELL_TEMP:
+      base: uint
+      start: 224
+      end: 232
+    MAX_TEMP_INT_SENSOR:
+      base: uint
+      start: 232
+      end: 240
+    MIN_TEMP_INT_SENSOR:
+      base: uint
+      start: 240
+      end: 248
+    MAX_TEMP_FET:
+      base: uint
+      start: 248
+      end: 256
 
 MAC_LIFETIME_DATA_BLOCK_2:
   type: command
   address: 0x446100
   size_bits_out: 64
   fields_out:
-    MIN_FCC_SOH_MAH:
+    NUM_SHUTDOWNS:
       base: uint
       start: 0
+      end: 8
+    NUM_PART_RESETS:
+      base: uint
+      start: 8
       end: 16
-    MIN_FCC_SOH_CWH:
+    NUM_FULL_RESETS:
       base: uint
       start: 16
+      end: 24
+    NUM_WDT_RESETS:
+      base: uint
+      start: 24
       end: 32
     CB_TIME_CELL_1:
       base: uint
@@ -1389,406 +1421,6 @@ MAC_LIFETIME_DATA_BLOCK_12:
       start: 224
       end: 256
 
-MAC_LIFETIME_DATA_BLOCK_13:
-  type: command
-  address: 0x446C00
-  size_bits_out: 240
-  fields_out:
-    MAX_TEMP_CELL_RELAX:
-      base: uint
-      start: 0
-      end: 8
-    MIN_TEMP_CELL_RELAX:
-      base: uint
-      start: 8
-      end: 16
-    MAX_DELTA_TEMP_CELL_RELAX:
-      base: uint
-      start: 16
-      end: 24
-    MAX_TEMP_INT_RELAX:
-      base: uint
-      start: 24
-      end: 32
-    MIN_TEMP_INT_RELAX:
-      base: uint
-      start: 32
-      end: 40
-    MAX_TEMP_FET_RELAX:
-      base: uint
-      start: 40
-      end: 48
-    MAX_TEMP_TS1_RELAX:
-      base: uint
-      start: 48
-      end: 56
-    MAX_TEMP_TS2_RELAX:
-      base: uint
-      start: 56
-      end: 64
-    MAX_TEMP_TS3_RELAX:
-      base: uint
-      start: 64
-      end: 72
-    MAX_TEMP_TS4_RELAX:
-      base: uint
-      start: 72
-      end: 80
-    MIN_TEMP_TS1_RELAX:
-      base: uint
-      start: 80
-      end: 88
-    MIN_TEMP_TS2_RELAX:
-      base: uint
-      start: 88
-      end: 96
-    MIN_TEMP_TS3_RELAX:
-      base: uint
-      start: 96
-      end: 104
-    MIN_TEMP_TS4_RELAX:
-      base: uint
-      start: 104
-      end: 112
-    MAX_TEMP_TMP468_1_RELAX:
-      base: uint
-      start: 112
-      end: 120
-    MAX_TEMP_TMP468_2_RELAX:
-      base: uint
-      start: 120
-      end: 128
-    MAX_TEMP_TMP468_3_RELAX:
-      base: uint
-      start: 128
-      end: 136
-    MAX_TEMP_TMP468_4_RELAX:
-      base: uint
-      start: 136
-      end: 144
-    MAX_TEMP_TMP468_5_RELAX:
-      base: uint
-      start: 144
-      end: 152
-    MAX_TEMP_TMP468_6_RELAX:
-      base: uint
-      start: 152
-      end: 160
-    MAX_TEMP_TMP468_7_RELAX:
-      base: uint
-      start: 160
-      end: 168
-    MAX_TEMP_TMP468_8_RELAX:
-      base: uint
-      start: 168
-      end: 176
-    MIN_TEMP_TMP468_1_RELAX:
-      base: uint
-      start: 176
-      end: 184
-    MIN_TEMP_TMP468_2_RELAX:
-      base: uint
-      start: 184
-      end: 192
-    MIN_TEMP_TMP468_3_RELAX:
-      base: uint
-      start: 192
-      end: 200
-    MIN_TEMP_TMP468_4_RELAX:
-      base: uint
-      start: 200
-      end: 208
-    MIN_TEMP_TMP468_5_RELAX:
-      base: uint
-      start: 208
-      end: 216
-    MIN_TEMP_TMP468_6_RELAX:
-      base: uint
-      start: 216
-      end: 224
-    MIN_TEMP_TMP468_7_RELAX:
-      base: uint
-      start: 224
-      end: 232
-    MIN_TEMP_TMP468_8_RELAX:
-      base: uint
-      start: 232
-      end: 240
-
-MAC_LIFETIME_DATA_BLOCK_14:
-  type: command
-  address: 0x446D00
-  size_bits_out: 240
-  fields_out:
-    MAX_TEMP_CELL_CHARGE:
-      base: uint
-      start: 0
-      end: 8
-    MIN_TEMP_CELL_CHARGE:
-      base: uint
-      start: 8
-      end: 16
-    MAX_DELTA_TEMP_CELL_CHARGE:
-      base: uint
-      start: 16
-      end: 24
-    MAX_TEMP_INT_CHARGE:
-      base: uint
-      start: 24
-      end: 32
-    MIN_TEMP_INT_CHARGE:
-      base: uint
-      start: 32
-      end: 40
-    MAX_TEMP_FET_CHARGE:
-      base: uint
-      start: 40
-      end: 48
-    MAX_TEMP_TS1_CHARGE:
-      base: uint
-      start: 48
-      end: 56
-    MAX_TEMP_TS2_CHARGE:
-      base: uint
-      start: 56
-      end: 64
-    MAX_TEMP_TS3_CHARGE:
-      base: uint
-      start: 64
-      end: 72
-    MAX_TEMP_TS4_CHARGE:
-      base: uint
-      start: 72
-      end: 80
-    MIN_TEMP_TS1_CHARGE:
-      base: uint
-      start: 80
-      end: 88
-    MIN_TEMP_TS2_CHARGE:
-      base: uint
-      start: 88
-      end: 96
-    MIN_TEMP_TS3_CHARGE:
-      base: uint
-      start: 96
-      end: 104
-    MIN_TEMP_TS4_CHARGE:
-      base: uint
-      start: 104
-      end: 112
-    MAX_TEMP_TMP468_1_CHARGE:
-      base: uint
-      start: 112
-      end: 120
-    MAX_TEMP_TMP468_2_CHARGE:
-      base: uint
-      start: 120
-      end: 128
-    MAX_TEMP_TMP468_3_CHARGE:
-      base: uint
-      start: 128
-      end: 136
-    MAX_TEMP_TMP468_4_CHARGE:
-      base: uint
-      start: 136
-      end: 144
-    MAX_TEMP_TMP468_5_CHARGE:
-      base: uint
-      start: 144
-      end: 152
-    MAX_TEMP_TMP468_6_CHARGE:
-      base: uint
-      start: 152
-      end: 160
-    MAX_TEMP_TMP468_7_CHARGE:
-      base: uint
-      start: 160
-      end: 168
-    MAX_TEMP_TMP468_8_CHARGE:
-      base: uint
-      start: 168
-      end: 176
-    MIN_TEMP_TMP468_1_CHARGE:
-      base: uint
-      start: 176
-      end: 184
-    MIN_TEMP_TMP468_2_CHARGE:
-      base: uint
-      start: 184
-      end: 192
-    MIN_TEMP_TMP468_3_CHARGE:
-      base: uint
-      start: 192
-      end: 200
-    MIN_TEMP_TMP468_4_CHARGE:
-      base: uint
-      start: 200
-      end: 208
-    MIN_TEMP_TMP468_5_CHARGE:
-      base: uint
-      start: 208
-      end: 216
-    MIN_TEMP_TMP468_6_CHARGE:
-      base: uint
-      start: 216
-      end: 224
-    MIN_TEMP_TMP468_7_CHARGE:
-      base: uint
-      start: 224
-      end: 232
-    MIN_TEMP_TMP468_8_CHARGE:
-      base: uint
-      start: 232
-      end: 240
-
-MAC_LIFETIME_DATA_BLOCK_15:
-  type: command
-  address: 0x446E00
-  size_bits_out: 240
-  fields_out:
-    MAX_TEMP_CELL_DISCHARGE:
-      base: uint
-      start: 0
-      end: 8
-    MIN_TEMP_CELL_DISCHARGE:
-      base: uint
-      start: 8
-      end: 16
-    MAX_DELTA_TEMP_CELL_DISCHARGE:
-      base: uint
-      start: 16
-      end: 24
-    MAX_TEMP_INT_DISCHARGE:
-      base: uint
-      start: 24
-      end: 32
-    MIN_TEMP_INT_DISCHARGE:
-      base: uint
-      start: 32
-      end: 40
-    MAX_TEMP_FET_DISCHARGE:
-      base: uint
-      start: 40
-      end: 48
-    MAX_TEMP_TS1_DISCHARGE:
-      base: uint
-      start: 48
-      end: 56
-    MAX_TEMP_TS2_DISCHARGE:
-      base: uint
-      start: 56
-      end: 64
-    MAX_TEMP_TS3_DISCHARGE:
-      base: uint
-      start: 64
-      end: 72
-    MAX_TEMP_TS4_DISCHARGE:
-      base: uint
-      start: 72
-      end: 80
-    MIN_TEMP_TS1_DISCHARGE:
-      base: uint
-      start: 80
-      end: 88
-    MIN_TEMP_TS2_DISCHARGE:
-      base: uint
-      start: 88
-      end: 96
-    MIN_TEMP_TS3_DISCHARGE:
-      base: uint
-      start: 96
-      end: 104
-    MIN_TEMP_TS4_DISCHARGE:
-      base: uint
-      start: 104
-      end: 112
-    MAX_TEMP_TMP468_1_DISCHARGE:
-      base: uint
-      start: 112
-      end: 120
-    MAX_TEMP_TMP468_2_DISCHARGE:
-      base: uint
-      start: 120
-      end: 128
-    MAX_TEMP_TMP468_3_DISCHARGE:
-      base: uint
-      start: 128
-      end: 136
-    MAX_TEMP_TMP468_4_DISCHARGE:
-      base: uint
-      start: 136
-      end: 144
-    MAX_TEMP_TMP468_5_DISCHARGE:
-      base: uint
-      start: 144
-      end: 152
-    MAX_TEMP_TMP468_6_DISCHARGE:
-      base: uint
-      start: 152
-      end: 160
-    MAX_TEMP_TMP468_7_DISCHARGE:
-      base: uint
-      start: 160
-      end: 168
-    MAX_TEMP_TMP468_8_DISCHARGE:
-      base: uint
-      start: 168
-      end: 176
-    MIN_TEMP_TMP468_1_DISCHARGE:
-      base: uint
-      start: 176
-      end: 184
-    MIN_TEMP_TMP468_2_DISCHARGE:
-      base: uint
-      start: 184
-      end: 192
-    MIN_TEMP_TMP468_3_DISCHARGE:
-      base: uint
-      start: 192
-      end: 200
-    MIN_TEMP_TMP468_4_DISCHARGE:
-      base: uint
-      start: 200
-      end: 208
-    MIN_TEMP_TMP468_5_DISCHARGE:
-      base: uint
-      start: 208
-      end: 216
-    MIN_TEMP_TMP468_6_DISCHARGE:
-      base: uint
-      start: 216
-      end: 224
-    MIN_TEMP_TMP468_7_DISCHARGE:
-      base: uint
-      start: 224
-      end: 232
-    MIN_TEMP_TMP468_8_DISCHARGE:
-      base: uint
-      start: 232
-      end: 240
-
-MAC_POWER_EVENTS:
-  type: command
-  address: 0x446F00
-  size_bits_out: 32
-  fields_out:
-    NUM_SHUTDOWNS:
-      base: uint
-      start: 0
-      end: 8
-    NUM_PART_RESETS:
-      base: uint
-      start: 8
-      end: 16
-    NUM_FULL_RESETS:
-      base: uint
-      start: 16
-      end: 24
-    NUM_WDT_RESETS:
-      base: uint
-      start: 24
-      end: 32
-
 MAC_MANUFACTURE_INFO:
   type: command
   address: 0x447000
@@ -1918,26 +1550,6 @@ MAC_DA_STATUS_2:
       base: uint
       start: 112
       end: 128
-    USER_TEMP:
-      base: uint
-      start: 128
-      end: 144
-    UNCOMP_CELL_V_1:
-      base: uint
-      start: 144
-      end: 160
-    UNCOMP_CELL_V_2:
-      base: uint
-      start: 160
-      end: 176
-    UNCOMP_CELL_V_3:
-      base: uint
-      start: 176
-      end: 192
-    UNCOMP_CELL_V_4:
-      base: uint
-      start: 192
-      end: 208
 
 MAC_GAUGE_STATUS_1:
   type: command
@@ -2238,46 +1850,12 @@ MAC_FILTER_CAPACITY:
 MAC_MANUFACTURE_INFO_B:
   type: command
   address: 0x447A00
-  size_bits_out: 256
+  size_bits_out: 32
   fields_out:
-    MANUFACTURE_INFO_B_0:
+    MANUFACTURE_INFO_B:
       base: uint
       start: 0
-      end: 64
-    MANUFACTURE_INFO_B_1:
-      base: uint
-      start: 64
-      end: 128
-    MANUFACTURE_INFO_B_2:
-      base: uint
-      start: 128
-      end: 192
-    MANUFACTURE_INFO_B_3:
-      base: uint
-      start: 192
-      end: 256
-
-MAC_MANUFACTURE_INFO_C:
-  type: command
-  address: 0x447B00
-  size_bits_out: 256
-  fields_out:
-    MANUFACTURE_INFO_C_0:
-      base: uint
-      start: 0
-      end: 64
-    MANUFACTURE_INFO_C_1:
-      base: uint
-      start: 64
-      end: 128
-    MANUFACTURE_INFO_C_2:
-      base: uint
-      start: 128
-      end: 192
-    MANUFACTURE_INFO_C_3:
-      base: uint
-      start: 192
-      end: 256
+      end: 32
 
 MAC_ROM_MODE:
   type: command
@@ -3927,7 +3505,7 @@ SUS_TURBO_CURRENT:
 LIFETIME_DATA_BLOCK_1:
   type: register
   address: 0x60
-  size_bits: 208
+  size_bits: 256
   access: RO
   fields:
     CELL_1_MAX_V:
@@ -3995,6 +3573,36 @@ LIFETIME_DATA_BLOCK_1:
       access: RO
       start: 192
       end: 208
+    MAX_TEMP_CELL:
+      base: uint
+      access: RO
+      start: 208
+      end: 216
+    MIN_TEMP_CELL:
+      base: uint
+      access: RO
+      start: 216
+      end: 224
+    MAX_DELTA_CELL_TEMP:
+      base: uint
+      access: RO
+      start: 224
+      end: 232
+    MAX_TEMP_INT_SENSOR:
+      base: uint
+      access: RO
+      start: 232
+      end: 240
+    MIN_TEMP_INT_SENSOR:
+      base: uint
+      access: RO
+      start: 240
+      end: 248
+    MAX_TEMP_FET:
+      base: uint
+      access: RO
+      start: 248
+      end: 256
 
 LIFETIME_DATA_BLOCK_2:
   type: register
@@ -4002,15 +3610,25 @@ LIFETIME_DATA_BLOCK_2:
   access: RO
   size_bits: 64
   fields:
-    MIN_FCC_SOH_MAH:
+    NUM_SHUTDOWNS:
       base: uint
       access: RO
       start: 0
+      end: 8
+    NUM_PART_RESETS:
+      base: uint
+      access: RO
+      start: 8
       end: 16
-    MIN_FCC_SOH_CWH:
+    NUM_FULL_RESETS:
       base: uint
       access: RO
       start: 16
+      end: 24
+    NUM_WDT_RESETS:
+      base: uint
+      access: RO
+      start: 24
       end: 32
     CB_TIME_CELL_1:
       base: uint
@@ -4570,7 +4188,7 @@ DA_STATUS_1:
 DA_STATUS_2:
   type: register
   address: 0x72
-  size_bits: 208
+  size_bits: 128
   access: RO
   fields:
     INT_TEMP:
@@ -4613,31 +4231,6 @@ DA_STATUS_2:
       access: RO
       start: 112
       end: 128
-    USER_TEMP:
-      base: uint
-      access: RO
-      start: 128
-      end: 144
-    UNCOMP_CELL_V_1:
-      base: uint
-      access: RO
-      start: 144
-      end: 160
-    UNCOMP_CELL_V_2:
-      base: uint
-      access: RO
-      start: 160
-      end: 176
-    UNCOMP_CELL_V_3:
-      base: uint
-      access: RO
-      start: 176
-      end: 192
-    UNCOMP_CELL_V_4:
-      base: uint
-      access: RO
-      start: 192
-      end: 208
 
 GAUGE_STATUS_1:
   type: register

--- a/device_R4.yaml
+++ b/device_R4.yaml
@@ -210,6 +210,62 @@ MAC_SEAL:
   type: command
   address: 0x443000
 
+MAC_SECURITY_KEYS:
+  type: command
+  address: 0x443500
+  size_bits_in: 64
+  fields_in:
+    UNSEAL_KEY_A:
+      base: uint
+      start: 0
+      end: 16
+    UNSEAL_KEY_B:
+      base: uint
+      start: 16
+      end: 32
+    FULL_ACCESS_KEY_A:
+      base: uint
+      start: 32
+      end: 48
+    FULL_ACCESS_KEY_B:
+      base: uint
+      start: 48
+      end: 64
+  size_bits_out: 64
+  fields_out:
+    UNSEAL_KEY_A:
+      base: uint
+      start: 0
+      end: 16
+    UNSEAL_KEY_B:
+      base: uint
+      start: 16
+      end: 32
+    FULL_ACCESS_KEY_A:
+      base: uint
+      start: 32
+      end: 48
+    FULL_ACCESS_KEY_B:
+      base: uint
+      start: 48
+      end: 64
+
+MAC_AUTH_KEY:
+  type: command
+  address: 0x443700
+  size_bits_in: 128
+  fields_in:
+    AUTHENTICATION_KEY:
+      base: uint
+      start: 0
+      end: 128
+  size_bits_out: 128
+  fields_out:
+    AUTHENTICATION_KEY:
+      base: uint
+      start: 0
+      end: 128
+
 MAC_DEVICE_RESET:
   type: command
   address: 0x444100
@@ -1571,6 +1627,28 @@ MAC_FILTER_CAPACITY:
       start: 48
       end: 64
 
+MAC_MANUFACTURE_INFO_B:
+  type: command
+  address: 0x447A00
+  size_bits_out: 256
+  fields_out:
+    MANUFACTURE_INFO_B_0:
+      base: uint
+      start: 0
+      end: 64
+    MANUFACTURE_INFO_B_1:
+      base: uint
+      start: 64
+      end: 128
+    MANUFACTURE_INFO_B_2:
+      base: uint
+      start: 128
+      end: 192
+    MANUFACTURE_INFO_B_3:
+      base: uint
+      start: 192
+      end: 256
+
 MAC_ROM_MODE:
   type: command
   address: 0x44000F
@@ -1706,32 +1784,6 @@ MAC_OUTPUT_SHORTED_CCADC_CAL:
       base: uint
       start: 176
       end: 192
-
-MAC_VOLTAGE_OVERRIDE:
-  type: command
-  address: 0x44B000
-  size_bits_out: 80
-  fields_out:
-    LOW_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 0
-      end: 16
-    STD_TEMP_LOW_CHARGE_VOLTAGE:
-      base: uint
-      start: 16
-      end: 32
-    STD_TEMP_HIGH_CHARGE_VOLTAGE:
-      base: uint
-      start: 32
-      end: 48
-    HIGH_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 48
-      end: 64
-    RECOMMENDED_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 64
-      end: 80
 
 REMAINING_CAPACITY_ALARM:
   type: register

--- a/device_R5.yaml
+++ b/device_R5.yaml
@@ -2279,6 +2279,44 @@ MAC_MANUFACTURE_INFO_C:
       start: 192
       end: 256
 
+MAC_LIFETIME_DATA_BLOCK_16:
+  type: command
+  address: 0x447E00
+  size_bits_out: 256
+  fields_out:
+    TIME_SPENT_LFT_UUT_RSOC_A:
+      base: uint
+      start: 0
+      end: 32
+    TIME_SPENT_LFT_UUT_RSOC_B:
+      base: uint
+      start: 32
+      end: 64
+    TIME_SPENT_LFT_UUT_RSOC_C:
+      base: uint
+      start: 64
+      end: 96
+    TIME_SPENT_LFT_UUT_RSOC_D:
+      base: uint
+      start: 96
+      end: 128
+    TIME_SPENT_LFT_UUT_RSOC_E:
+      base: uint
+      start: 128
+      end: 160
+    TIME_SPENT_LFT_UUT_RSOC_F:
+      base: uint
+      start: 160
+      end: 192
+    TIME_SPENT_LFT_UUT_RSOC_G:
+      base: uint
+      start: 192
+      end: 224
+    TIME_SPENT_LFT_UUT_RSOC_H:
+      base: uint
+      start: 224
+      end: 256
+
 MAC_ROM_MODE:
   type: command
   address: 0x44000F

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,11 @@ pub enum BQ40Z50Error<I2cError> {
 }
 
 // Gated as future revisions of this chip may have larger register sizes.
-#[cfg(any(feature = "r1", feature = "r4"))]
+#[cfg(any(feature = "r1", feature = "r3", feature = "r4", feature = "r5"))]
 const LARGEST_REG_SIZE_BYTES: usize = 5;
-#[cfg(any(feature = "r1", feature = "r4"))]
+#[cfg(any(feature = "r1", feature = "r3", feature = "r4", feature = "r5"))]
 const LARGEST_CMD_SIZE_BYTES: usize = 32;
-#[cfg(any(feature = "r1", feature = "r4"))]
+#[cfg(any(feature = "r1", feature = "r3", feature = "r4", feature = "r5"))]
 const LARGEST_BUF_SIZE_BYTES: usize = 33;
 
 const BQ_ADDR: u8 = 0x0Bu8;
@@ -105,10 +105,22 @@ device_driver::create_device!(
     manifest: "device_R1.yaml"
 );
 
+#[cfg(feature = "r3")]
+device_driver::create_device!(
+    device_name: Device,
+    manifest: "device_R3.yaml"
+);
+
 #[cfg(feature = "r4")]
 device_driver::create_device!(
     device_name: Device,
     manifest: "device_R4.yaml"
+);
+
+#[cfg(feature = "r5")]
+device_driver::create_device!(
+    device_name: Device,
+    manifest: "device_R5.yaml"
 );
 
 impl<I2C: I2cTrait> device_driver::AsyncRegisterInterface for DeviceInterface<I2C> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,10 +28,15 @@ pub enum BQ40Z50Error<I2cError> {
     BatteryStatus(ErrorCode),
 }
 
-const BQ_ADDR: u8 = 0x0B;
+// Gated as future revisions of this chip may have larger register sizes.
+#[cfg(any(feature = "r1", feature = "r4"))]
 const LARGEST_REG_SIZE_BYTES: usize = 5;
+#[cfg(any(feature = "r1", feature = "r4"))]
 const LARGEST_CMD_SIZE_BYTES: usize = 32;
+#[cfg(any(feature = "r1", feature = "r4"))]
 const LARGEST_BUF_SIZE_BYTES: usize = 33;
+
+const BQ_ADDR: u8 = 0x0Bu8;
 const MAC_CMD_ADDR_SIZE_BYTES: u8 = 2;
 const MAC_CMD_ADDR_SIZE_BITS: u8 = MAC_CMD_ADDR_SIZE_BYTES * 8;
 const MAC_CMD: u8 = 0x44u8;
@@ -94,9 +99,16 @@ pub struct DeviceInterface<I2C: I2cTrait> {
     pub i2c: I2C,
 }
 
+#[cfg(feature = "r1")]
 device_driver::create_device!(
     device_name: Device,
-    manifest: "device.yaml"
+    manifest: "device_R1.yaml"
+);
+
+#[cfg(feature = "r4")]
+device_driver::create_device!(
+    device_name: Device,
+    manifest: "device_R4.yaml"
 );
 
 impl<I2C: I2cTrait> device_driver::AsyncRegisterInterface for DeviceInterface<I2C> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,10 @@
 //! For further details of the device architecture and operation, please refer
 //! to the official [`Datasheet`].
 //!
-//! [`Datasheet`]: https://www.ti.com/lit/ug/sluua43a/sluua43a.pdf
+//! [`Datasheet R1`]: https://www.ti.com/lit/ug/sluua43a/sluua43a.pdf
+//! [`Datasheet R3`]: https://www.ti.com/lit/ug/sluubu5a/sluubu5a.pdf
+//! [`Datasheet R4`]: https://www.ti.com/lit/ug/sluuch2/sluuch2.pdf
+//! [`Datasheet R5`]: https://www.ti.com/lit/ug/sluucn4b/sluucn4b.pdf
 
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(test), no_std)]


### PR DESCRIPTION
- Add mutually exclusive features `r1`, `r3`, `r4`, `r5` for users to choose which rev of the chip they're using
- Add register definitions for each 
- Updates CI to test the mutually exclusive features
- Removal of cargo hack CI workflow since there is no way to skip a featureless build with cargo hack
- Adds compile time checks to enforce mutual exclusion on the revision features
- Also adds extra missing fields to the Cargo.toml

Long PR due to the renaming and duplication of manifest file.