### PR TITLE
Fix rust SAM build error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -730,13 +730,13 @@ impl<I2C: I2cTrait> smart_battery::SmartBattery for Bq40z50<I2C> {
         self.device.device_chemistry().read_async(chemistry).await.map(|_f| ())
     }
 
-    async fn charging_current(&mut self) -> Result<embedded_batteries_async::charger::MilliAmps, Self::Error> {
-        Ok(self.device.charging_current().read_async().await?.charging_current())
-    }
+    // async fn charging_current(&mut self) -> Result<embedded_batteries_async::charger::MilliAmps, Self::Error> {
+    //     Ok(self.device.charging_current().read_async().await?.charging_current())
+    // }
 
-    async fn charging_voltage(&mut self) -> Result<smart_battery::MilliVolts, Self::Error> {
-        Ok(self.device.charging_voltage().read_async().await?.charging_voltage())
-    }
+    // async fn charging_voltage(&mut self) -> Result<smart_battery::MilliVolts, Self::Error> {
+    //     Ok(self.device.charging_voltage().read_async().await?.charging_voltage())
+    // }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Cargo update is blocked in current Rust SAM codes, if take latest commit of bq40z50 which fixed factory command issues, it will cause below build error. To unblock current build and take latest fix, comment out these two functions as a workaround now.
 _

> impl SmartBattery for Bq40z50Controller {
>     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `charging_current`, `charging_voltage` in implementation
>     |

_