### PR TITLE
Add MAC register 0x00B0 configuration

### DIFF
--- a/device.yaml
+++ b/device.yaml
@@ -1707,6 +1707,32 @@ MAC_OUTPUT_SHORTED_CCADC_CAL:
       start: 176
       end: 192
 
+MAC_VOLTAGE_OVERRIDE:
+  type: command
+  address: 0x44B000
+  size_bits_out: 80
+  fields_out:
+    LOW_TEMP_CHARGE_VOLTAGE:
+      base: uint
+      start: 0
+      end: 16
+    STD_TEMP_LOW_CHARGE_VOLTAGE:
+      base: uint
+      start: 16
+      end: 32
+    STD_TEMP_HIGH_CHARGE_VOLTAGE:
+      base: uint
+      start: 32
+      end: 48
+    HIGH_TEMP_CHARGE_VOLTAGE:
+      base: uint
+      start: 48
+      end: 64
+    RECOMMENDED_TEMP_CHARGE_VOLTAGE:
+      base: uint
+      start: 64
+      end: 80
+
 REMAINING_CAPACITY_ALARM:
   type: register
   address: 0x01


### PR DESCRIPTION
Why: surfdbg command .bat regs need to access ManufacturerAccess() 0x00B0 ChargingVoltageOverride
Changed: Add configuration to device.yaml
How tested:  Run with PR [Pull Request 327768](https://dev.azure.com/MSFTDEVICES/MCU/_git/rs-surface-mcu/pullrequest/327768): Battery SS: add Readregs command support
It works well
![image](https://github.com/user-attachments/assets/355cf244-d7bc-44b8-a8ba-62ce65af8cd2)
