### PR TITLE
Update embedded-batteries-async to v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ defmt = { version = "0.3", optional = true }
 
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
-embedded-batteries-async = "0.1.0"
+embedded-batteries-async = "0.2.0"
 
 [dev-dependencies]
 embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bq40z50-rx"
-version = "0.1.0"
+version = "0.1.1"
 repository = "https://github.com/OpenDevicePartnership/bq40z50"
 license = "MIT"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]


### PR DESCRIPTION
TBH embedded-batteries-async should not have been a new major change, it just added non-breaking structs. Regardless, update to provide ACPI functionality that downstream users can use.