### PR TITLE
Add timeout support via embassy-time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bq40z50-rx"
-version = "0.2.0"
+version = "0.3.0"
 repository = "https://github.com/OpenDevicePartnership/bq40z50"
 license = "MIT"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]
@@ -28,10 +28,17 @@ defmt = { version = "0.3", optional = true }
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 embedded-batteries-async = "0.2.0"
+embassy-time = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }
 tokio = { version = "1.42.0", features = ["rt", "macros"] }
+embassy-time = { version = "0.4.0", features = ["std"] }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy/", features = [
+	"arch-std",
+	"executor-thread",
+] }
+static_cell = "2.1.1"
 
 [lints.rust]
 unsafe_code = "deny"
@@ -46,10 +53,13 @@ style = "forbid"
 pedantic = "deny"
 
 [features]
+embassy-timeout = ["dep:embassy-time"]
 defmt-03 = [
 	"dep:defmt",
 	"device-driver/defmt-03",
 	"embedded-batteries-async/defmt",
+	"embassy-time/defmt",
+	"embassy-time/defmt-timestamp-uptime",
 ]
 r1 = []
 r3 = []


### PR DESCRIPTION
This change adds functionality to timeout all i2c transactions in case the fuel gauge gets stuck/takes too long to respond.

Default timeout is 100ms but it can be changed by passing in a timeout value at driver construction time.

Includes the changes for retries and backoff delay too.

Uprev to v0.3.0 as this is a breaking change.

**NOTE:** This change includes a dependency on the _crates.io version of embassy time._ This is done because crates in crates.io must be semantically versioned, and not use git references. If you are using the git ref version in your project's `Cargo.toml`, you will likely run into multiple dependency issues. To resolve this, a new branch with the git version of embassy-time will be maintained alongside the `main` branch, please point your `Cargo.toml` to use that version instead.