### PR TITLE
Switch embassy-time from semver to git version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,12 @@ defmt = { version = "0.3", optional = true }
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 embedded-batteries-async = "0.2.0"
-embassy-time = { version = "0.4.0", optional = true }
+embassy-time = { git = "https://github.com/embassy-rs/embassy/", optional = true }
 
 [dev-dependencies]
 embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }
 tokio = { version = "1.42.0", features = ["rt", "macros"] }
-embassy-time = { version = "0.4.0", features = ["std"] }
+embassy-time = { git = "https://github.com/embassy-rs/embassy/", features = ["std"] }
 embassy-executor = { git = "https://github.com/embassy-rs/embassy/", features = [
 	"arch-std",
 	"executor-thread",


### PR DESCRIPTION
From #32 

> NOTE: This change includes a dependency on the crates.io version of embassy time. This is done because crates in crates.io must be semantically versioned, and not use git references. If you are using the git ref version in your project's Cargo.toml, you will likely run into multiple dependency issues. To resolve this, a new branch with the git version of embassy-time will be maintained alongside the main branch, please point your Cargo.toml to use that version instead.

Needed to compile projects that use the git version of embassy-time as a dependency.
Add to your project like:
`bq40z50-rx = { git = "https://github.com/OpenDevicePartnership/bq40z50", branch = "embassy-time-git-ref", features = ["r5", "embassy-timeout"] }`