### PR TITLE
Add write functionality to ChargingVoltageOverride MAC command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bq40z50-rx"
-version = "0.5.0"
+version = "0.5.1"
 repository = "https://github.com/OpenDevicePartnership/bq40z50"
 license = "MIT"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]

--- a/device_R1.yaml
+++ b/device_R1.yaml
@@ -1707,32 +1707,6 @@ MAC_OUTPUT_SHORTED_CCADC_CAL:
       start: 176
       end: 192
 
-MAC_VOLTAGE_OVERRIDE:
-  type: command
-  address: 0x44B000
-  size_bits_out: 80
-  fields_out:
-    LOW_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 0
-      end: 16
-    STD_TEMP_LOW_CHARGE_VOLTAGE:
-      base: uint
-      start: 16
-      end: 32
-    STD_TEMP_HIGH_CHARGE_VOLTAGE:
-      base: uint
-      start: 32
-      end: 48
-    HIGH_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 48
-      end: 64
-    RECOMMENDED_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 64
-      end: 80
-
 REMAINING_CAPACITY_ALARM:
   type: register
   address: 0x01

--- a/device_R3.yaml
+++ b/device_R3.yaml
@@ -1993,32 +1993,6 @@ MAC_OUTPUT_SHORTED_CCADC_CAL:
       start: 176
       end: 192
 
-MAC_VOLTAGE_OVERRIDE:
-  type: command
-  address: 0x44B000
-  size_bits_out: 80
-  fields_out:
-    LOW_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 0
-      end: 16
-    STD_TEMP_LOW_CHARGE_VOLTAGE:
-      base: uint
-      start: 16
-      end: 32
-    STD_TEMP_HIGH_CHARGE_VOLTAGE:
-      base: uint
-      start: 32
-      end: 48
-    HIGH_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 48
-      end: 64
-    RECOMMENDED_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 64
-      end: 80
-
 REMAINING_CAPACITY_ALARM:
   type: register
   address: 0x01

--- a/device_R4.yaml
+++ b/device_R4.yaml
@@ -2393,32 +2393,6 @@ MAC_OUTPUT_SHORTED_CCADC_CAL:
       start: 176
       end: 192
 
-MAC_VOLTAGE_OVERRIDE:
-  type: command
-  address: 0x44B000
-  size_bits_out: 80
-  fields_out:
-    LOW_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 0
-      end: 16
-    STD_TEMP_LOW_CHARGE_VOLTAGE:
-      base: uint
-      start: 16
-      end: 32
-    STD_TEMP_HIGH_CHARGE_VOLTAGE:
-      base: uint
-      start: 32
-      end: 48
-    HIGH_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 48
-      end: 64
-    RECOMMENDED_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 64
-      end: 80
-
 REMAINING_CAPACITY_ALARM:
   type: register
   address: 0x01

--- a/device_R5.yaml
+++ b/device_R5.yaml
@@ -2431,32 +2431,6 @@ MAC_OUTPUT_SHORTED_CCADC_CAL:
       start: 176
       end: 192
 
-MAC_VOLTAGE_OVERRIDE:
-  type: command
-  address: 0x44B000
-  size_bits_out: 80
-  fields_out:
-    LOW_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 0
-      end: 16
-    STD_TEMP_LOW_CHARGE_VOLTAGE:
-      base: uint
-      start: 16
-      end: 32
-    STD_TEMP_HIGH_CHARGE_VOLTAGE:
-      base: uint
-      start: 32
-      end: 48
-    HIGH_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 48
-      end: 64
-    RECOMMENDED_TEMP_CHARGE_VOLTAGE:
-      base: uint
-      start: 64
-      end: 80
-
 REMAINING_CAPACITY_ALARM:
   type: register
   address: 0x01


### PR DESCRIPTION
Add write access to MAC command 0x00B0 ChargingVoltageOverride()

Added unit tests to verify write and read functionality.