### PR TITLE
Publicly re-export autogenerated field sets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bq40z50-rx"
-version = "0.6.0"
+version = "0.6.1"
 repository = "https://github.com/OpenDevicePartnership/bq40z50"
 license = "MIT"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,3 +40,4 @@ pub use versions::r3::Bq40z50R3;
 pub use versions::r4::Bq40z50R4;
 #[cfg(feature = "r5")]
 pub use versions::r5::Bq40z50R5;
+pub use versions::*;


### PR DESCRIPTION
In the refactor PR, there is an issue where the field sets aren't re-exported and thus, driver users can't construct autogenerated fields and use its associated methods. Re-export these field sets.