### PR TITLE
Add DataTooLarge error handling for public methods that take in a slice of bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bq40z50-rx"
-version = "0.6.1"
+version = "0.7.0"
 repository = "https://github.com/OpenDevicePartnership/bq40z50"
 license = "MIT"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ pub enum BQ40Z50Error<I2cError> {
     BatteryStatus(embedded_batteries_async::smart_battery::ErrorCode),
     Timeout,
     Pec,
+    DataTooLarge,
 }
 
 #[cfg(feature = "embassy-timeout")]
@@ -20,7 +21,7 @@ impl<E: embedded_hal_async::i2c::Error> embedded_batteries_async::smart_battery:
         match self {
             Self::I2c(_) => embedded_batteries_async::smart_battery::ErrorKind::CommError,
             Self::BatteryStatus(e) => embedded_batteries_async::smart_battery::ErrorKind::BatteryStatus(*e),
-            Self::Timeout | Self::Pec => embedded_batteries_async::smart_battery::ErrorKind::Other,
+            Self::Timeout | Self::Pec | Self::DataTooLarge => embedded_batteries_async::smart_battery::ErrorKind::Other,
         }
     }
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -111,7 +111,7 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> DeviceInterface<I2C, DELAY> {
         write: &[u8],
         use_pec: bool,
     ) -> Result<(), BQ40Z50Error<I2C::Error>> {
-        let mut write_buf = [0u8; 1 + LARGEST_REG_SIZE_BYTES];
+        let mut write_buf = [0u8; 1 + LARGEST_REG_SIZE_BYTES + 6];
         let write_buf_ref: &[u8];
         if use_pec {
             let mut pec = smbus_pec::Pec::default();
@@ -138,8 +138,8 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> DeviceInterface<I2C, DELAY> {
         use_pec: bool,
     ) -> Result<(), BQ40Z50Error<I2C::Error>> {
         let mut retries = self.config.max_bus_retries;
-        // Read buffer with one extra space at the end, in case we use PEC
-        let mut read_buf = [0u8; 1 + LARGEST_REG_SIZE_BYTES];
+        // Read buffer with one extra space at the end, in case we use PEC, and one extra space in the front for `mfg_info`
+        let mut read_buf = [0u8; 1 + LARGEST_REG_SIZE_BYTES + 1];
         let mut pec = smbus_pec::Pec::default();
 
         let read_len = read.len();
@@ -486,7 +486,7 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> DeviceInterface<I2C, DELAY> {
         write: &[u8],
         use_pec: bool,
     ) -> Result<(), BQ40Z50Error<I2C::Error>> {
-        let mut write_buf = [0u8; 1 + LARGEST_REG_SIZE_BYTES];
+        let mut write_buf = [0u8; 1 + LARGEST_REG_SIZE_BYTES + 6];
         let write_buf_ref: &[u8];
         if use_pec {
             let mut pec = smbus_pec::Pec::default();
@@ -513,8 +513,8 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> DeviceInterface<I2C, DELAY> {
         use_pec: bool,
     ) -> Result<(), BQ40Z50Error<I2C::Error>> {
         let mut retries = self.config.max_bus_retries;
-        // Read buffer with one extra space at the end, in case we use PEC
-        let mut read_buf = [0u8; 1 + LARGEST_REG_SIZE_BYTES];
+        // Read buffer with one extra space at the end, in case we use PEC, and one extra space in the front for `mfg_info`
+        let mut read_buf = [0u8; 1 + LARGEST_REG_SIZE_BYTES + 1];
         let mut pec = smbus_pec::Pec::default();
 
         let read_len = read.len();

--- a/src/versions/r1.rs
+++ b/src/versions/r1.rs
@@ -268,7 +268,10 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R1<I2C, DELAY> {
     /// Will return `Err` if an I2C bus error occurs.
     #[allow(clippy::cast_possible_truncation)]
     pub async fn write_mfg_info(&mut self, data: &[u8]) -> Result<(), BQ40Z50Error<I2C::Error>> {
-        let mut buf = [0u8; 2 + LARGEST_BUF_SIZE_BYTES];
+        if data.len() > LARGEST_REG_SIZE_BYTES {
+            return Err(BQ40Z50Error::DataTooLarge);
+        }
+        let mut buf = [0u8; 2 + LARGEST_REG_SIZE_BYTES];
         buf[0] = MFG_INFO_CMD;
         buf[1] = data.len() as u8;
         buf[2..data.len() + 2].copy_from_slice(data);
@@ -281,16 +284,24 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R1<I2C, DELAY> {
 
     /// Read from the `MfgInfo` register.
     ///
-    /// `data` can be at most 32 bytes large.
+    /// NOTE: `mfg_info` is unique in that it has a leading size byte,
+    /// meaning you need to read 33 bytes to read 32 bytes of data.
+    /// This fn will return the data including the size byte as the zeroth byte.
+    ///
+    /// `data` can be at most 33 bytes large, which includes the size byte in the zeroth position.
     /// # Errors
     ///
     /// Will return `Err` if an I2C bus error occurs.
     pub async fn read_mfg_info(&mut self, data: &mut [u8]) -> Result<(), BQ40Z50Error<I2C::Error>> {
+        if data.len() > LARGEST_REG_SIZE_BYTES + 1 {
+            return Err(BQ40Z50Error::DataTooLarge);
+        }
         if self.device.interface.config.pec_read {
             // If reading with PEC, the entire payload needs to be read to verify the PEC byte
             // This reduces performance because without PEC, we could read parts of the register and NACK early if we
             // know the size of the data we want to read.
-            let mut read_buf = [0u8; 32];
+            // [ size | data | data | ... | data | PEC (optional) ]
+            let mut read_buf = [0u8; LARGEST_REG_SIZE_BYTES + 1];
             self.device
                 .interface
                 .read_with_retries(&[MFG_INFO_CMD], &mut read_buf, true)

--- a/src/versions/r4.rs
+++ b/src/versions/r4.rs
@@ -272,6 +272,9 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R4<I2C, DELAY> {
     #[allow(clippy::cast_possible_truncation)]
     pub async fn write_mfg_info_c(&mut self, data: &[u8]) -> Result<(), BQ40Z50Error<I2C::Error>> {
         const MFG_INFO_C_CMD: [u8; MAC_CMD_ADDR_SIZE_BYTES as usize] = 0x007Bu16.to_le_bytes();
+        if data.len() > LARGEST_CMD_SIZE_BYTES {
+            return Err(BQ40Z50Error::DataTooLarge);
+        }
         let mut buf = [0u8; 4 + LARGEST_CMD_SIZE_BYTES];
 
         // Write data
@@ -294,6 +297,9 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R4<I2C, DELAY> {
     /// Will return `Err` if an I2C bus error occurs.
     pub async fn read_mfg_info_c(&mut self, data: &mut [u8]) -> Result<(), BQ40Z50Error<I2C::Error>> {
         const MFG_INFO_C_CMD: [u8; MAC_CMD_ADDR_SIZE_BYTES as usize] = 0x007Bu16.to_le_bytes();
+        if data.len() > LARGEST_CMD_SIZE_BYTES {
+            return Err(BQ40Z50Error::DataTooLarge);
+        }
 
         let mut buf = [0u8; 4];
         buf[0] = MAC_CMD;
@@ -330,7 +336,10 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R4<I2C, DELAY> {
     /// Will return `Err` if an I2C bus error occurs.
     #[allow(clippy::cast_possible_truncation)]
     pub async fn write_mfg_info(&mut self, data: &[u8]) -> Result<(), BQ40Z50Error<I2C::Error>> {
-        let mut buf = [0u8; 2 + LARGEST_BUF_SIZE_BYTES];
+        if data.len() > LARGEST_REG_SIZE_BYTES {
+            return Err(BQ40Z50Error::DataTooLarge);
+        }
+        let mut buf = [0u8; 2 + LARGEST_REG_SIZE_BYTES];
         buf[0] = MFG_INFO_CMD;
         buf[1] = data.len() as u8;
         buf[2..data.len() + 2].copy_from_slice(data);
@@ -343,16 +352,24 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R4<I2C, DELAY> {
 
     /// Read from the `MfgInfo` register.
     ///
-    /// `data` can be at most 32 bytes large.
+    /// NOTE: `mfg_info` is unique in that it has a leading size byte,
+    /// meaning you need to read 33 bytes to read 32 bytes of data.
+    /// This fn will return the data including the size byte as the zeroth byte.
+    ///
+    /// `data` can be at most 33 bytes large, which includes the size byte in the zeroth position.
     /// # Errors
     ///
     /// Will return `Err` if an I2C bus error occurs.
     pub async fn read_mfg_info(&mut self, data: &mut [u8]) -> Result<(), BQ40Z50Error<I2C::Error>> {
+        if data.len() > LARGEST_REG_SIZE_BYTES + 1 {
+            return Err(BQ40Z50Error::DataTooLarge);
+        }
         if self.device.interface.config.pec_read {
             // If reading with PEC, the entire payload needs to be read to verify the PEC byte
             // This reduces performance because without PEC, we could read parts of the register and NACK early if we
             // know the size of the data we want to read.
-            let mut read_buf = [0u8; 32];
+            // [ size | data | data | ... | data | PEC (optional) ]
+            let mut read_buf = [0u8; LARGEST_REG_SIZE_BYTES + 1];
             self.device
                 .interface
                 .read_with_retries(&[MFG_INFO_CMD], &mut read_buf, true)

--- a/src/versions/r5.rs
+++ b/src/versions/r5.rs
@@ -276,6 +276,9 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R5<I2C, DELAY> {
         data: &[u8],
     ) -> Result<(), BQ40Z50Error<I2C::Error>> {
         const MFG_INFO_C_CMD: [u8; MAC_CMD_ADDR_SIZE_BYTES as usize] = 0x007Bu16.to_le_bytes();
+        if data.len() > LARGEST_CMD_SIZE_BYTES {
+            return Err(BQ40Z50Error::DataTooLarge);
+        }
         let mut buf = [0u8; 4 + LARGEST_CMD_SIZE_BYTES];
 
         self.send_access_key(access_key_lower, access_key_upper).await?;
@@ -301,6 +304,9 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R5<I2C, DELAY> {
     /// Will return `Err` if an I2C bus error occurs.
     pub async fn read_mfg_info_c(&mut self, data: &mut [u8]) -> Result<(), BQ40Z50Error<I2C::Error>> {
         const MFG_INFO_C_CMD: [u8; MAC_CMD_ADDR_SIZE_BYTES as usize] = 0x007Bu16.to_le_bytes();
+        if data.len() > LARGEST_CMD_SIZE_BYTES {
+            return Err(BQ40Z50Error::DataTooLarge);
+        }
 
         let mut buf = [0u8; 4];
         buf[0] = MAC_CMD;
@@ -337,7 +343,10 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R5<I2C, DELAY> {
     /// Will return `Err` if an I2C bus error occurs.
     #[allow(clippy::cast_possible_truncation)]
     pub async fn write_mfg_info(&mut self, data: &[u8]) -> Result<(), BQ40Z50Error<I2C::Error>> {
-        let mut buf = [0u8; 2 + LARGEST_BUF_SIZE_BYTES];
+        if data.len() > LARGEST_REG_SIZE_BYTES {
+            return Err(BQ40Z50Error::DataTooLarge);
+        }
+        let mut buf = [0u8; 2 + LARGEST_REG_SIZE_BYTES];
         buf[0] = MFG_INFO_CMD;
         buf[1] = data.len() as u8;
         buf[2..data.len() + 2].copy_from_slice(data);
@@ -350,26 +359,34 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R5<I2C, DELAY> {
 
     /// Read from the `MfgInfo` register.
     ///
-    /// `data` can be at most 32 bytes large.
+    /// NOTE: `mfg_info` is unique in that it has a leading size byte,
+    /// meaning you need to read 33 bytes to read 32 bytes of data.
+    /// This fn will return the data including the size byte as the zeroth byte.
+    ///
+    /// `data` can be at most 33 bytes large, which includes the size byte in the zeroth position.
     /// # Errors
     ///
     /// Will return `Err` if an I2C bus error occurs.
     pub async fn read_mfg_info(&mut self, data: &mut [u8]) -> Result<(), BQ40Z50Error<I2C::Error>> {
+        if data.len() > LARGEST_REG_SIZE_BYTES + 1 {
+            return Err(BQ40Z50Error::DataTooLarge);
+        }
         if self.device.interface.config.pec_read {
             // If reading with PEC, the entire payload needs to be read to verify the PEC byte
             // This reduces performance because without PEC, we could read parts of the register and NACK early if we
             // know the size of the data we want to read.
-            let mut read_buf = [0u8; 32];
+            // [ size | data | data | ... | data | PEC (optional) ]
+            let mut read_buf = [0u8; LARGEST_REG_SIZE_BYTES + 1];
             self.device
                 .interface
-                .read_with_retries(&[MFG_INFO_CMD], &mut read_buf, self.device.interface.config.pec_read)
+                .read_with_retries(&[MFG_INFO_CMD], &mut read_buf, true)
                 .await?;
             data.copy_from_slice(&read_buf[..data.len()]);
             Ok(())
         } else {
             self.device
                 .interface
-                .read_with_retries(&[MFG_INFO_CMD], data, self.device.interface.config.pec_read)
+                .read_with_retries(&[MFG_INFO_CMD], data, false)
                 .await
         }
     }


### PR DESCRIPTION
The manufacture info register accessors are passed an arbitrarily sized number of bytes as an argument. Enforce a limit on these methods in case a slice that is too large is passed in.

Additionally, fix regression introduced with PEC PR with data staging arrays not being large enough and overrunning the buffer.

Semver wants a breaking change because of new Error enum introduced, so uprev to 0.7.0