### PR TITLE
Fix incorrect charging status register definitions in r3 and r4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bq40z50-rx"
-version = "0.7.1"
+version = "0.7.2"
 repository = "https://github.com/OpenDevicePartnership/bq40z50"
 license = "MIT"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]

--- a/device_R3.yaml
+++ b/device_R3.yaml
@@ -664,21 +664,33 @@ MAC_CHARGING_STATUS:
     CHG_IN:
       base: bool
       start: 12
-    MCHG:
+    CHG_SU:
       base: bool
       start: 13
-    VCT:
+    MCHG:
       base: bool
       start: 14
-    CCR:
+    VCT:
       base: bool
       start: 15
-    CVR:
+    CCR:
       base: bool
       start: 16
-    CCC:
+    CVR:
       base: bool
       start: 17
+    CCC:
+      base: bool
+      start: 18
+    NCT:
+      base: bool
+      start: 19
+    ERM:
+      base: bool
+      start: 20
+    ERETM:
+      base: bool
+      start: 21
 
 MAC_GAUGING_STATUS:
   type: command
@@ -3121,26 +3133,42 @@ CHARGING_STATUS:
       base: bool
       access: RO
       start: 12
-    MCHG:
+    CHG_SU:
       base: bool
       access: RO
       start: 13
-    VCT:
+    MCHG:
       base: bool
       access: RO
       start: 14
-    CCR:
+    VCT:
       base: bool
       access: RO
       start: 15
-    CVR:
+    CCR:
       base: bool
       access: RO
       start: 16
-    CCC:
+    CVR:
       base: bool
       access: RO
       start: 17
+    CCC:
+      base: bool
+      access: RO
+      start: 18
+    NCT:
+      base: bool
+      access: RO
+      start: 19
+    ERM:
+      base: bool
+      access: RO
+      start: 20
+    ERETM:
+      base: bool
+      access: RO
+      start: 21
 
 GAUGING_STATUS:
   type: register

--- a/device_R4.yaml
+++ b/device_R4.yaml
@@ -664,21 +664,43 @@ MAC_CHARGING_STATUS:
     CHG_IN:
       base: bool
       start: 12
-    MCHG:
+    CHG_SU:
       base: bool
       start: 13
-    VCT:
+    MCHG:
       base: bool
       start: 14
-    CCR:
+    VCT:
       base: bool
       start: 15
-    CVR:
+    CCR:
       base: bool
       start: 16
-    CCC:
+    CVR:
       base: bool
       start: 17
+    CCC:
+      base: bool
+      start: 18
+    NCT:
+      base: bool
+      start: 19
+    ERM:
+      base: bool
+      start: 20
+    ERETM:
+      base: bool
+      start: 21
+    DEG:
+      base: uint
+      start: 22
+      end: 24
+      conversion:
+        name: "DegradationMode"
+        NoDegradation: 0
+        CycleCountBased: 1
+        SohBased: 2
+        RuntimeBased: 3
 
 MAC_GAUGING_STATUS:
   type: command
@@ -3521,26 +3543,48 @@ CHARGING_STATUS:
       base: bool
       access: RO
       start: 12
-    MCHG:
+    CHG_SU:
       base: bool
       access: RO
       start: 13
-    VCT:
+    MCHG:
       base: bool
       access: RO
       start: 14
-    CCR:
+    VCT:
       base: bool
       access: RO
       start: 15
-    CVR:
+    CCR:
       base: bool
       access: RO
       start: 16
-    CCC:
+    CVR:
       base: bool
       access: RO
       start: 17
+    CCC:
+      base: bool
+      access: RO
+      start: 18
+    NCT:
+      base: bool
+      access: RO
+      start: 19
+    ERM:
+      base: bool
+      access: RO
+      start: 20
+    ERETM:
+      base: bool
+      access: RO
+      start: 21
+    DEG:
+      base: uint
+      access: RO
+      start: 22
+      end: 24
+      conversion: "DegradationMode"
 
 GAUGING_STATUS:
   type: register


### PR DESCRIPTION
After merging #48, I did some more digging and found that the charging status register definitions in r3 and r4 are also incorrect, as TI introduced a bit in between other existing bits.