### PR TITLE
Allow changing driver config on the fly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "bq40z50-rx"
-version = "0.8.0"
+version = "0.8.1"
 repository = "https://github.com/OpenDevicePartnership/bq40z50"
 license = "MIT"
-authors = ["Matteo Tullo <matteotullo@microsoft.com>"]
 rust-version = "1.85"
 description = "Platform-agnostic Rust driver for the Texas Instruments BQ40Z50 battery fuel (gas) gauge."
 readme = "README.md"

--- a/src/common.rs
+++ b/src/common.rs
@@ -13,8 +13,9 @@ pub struct Config {
     pub timeout: embassy_time::Duration,
 }
 
-impl Default for Config {
-    fn default() -> Self {
+impl Config {
+    #[must_use]
+    pub const fn new() -> Self {
         Self {
             max_bus_retries: crate::consts::DEFAULT_BUS_RETRIES,
             pec_read: false,
@@ -22,6 +23,12 @@ impl Default for Config {
             #[cfg(feature = "embassy-timeout")]
             timeout: crate::consts::DEFAULT_TIMEOUT,
         }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -21,12 +21,18 @@ pub struct DeviceInterface<I2C: I2cTrait, DELAY: DelayTrait> {
 }
 
 impl<I2C: I2cTrait, DELAY: DelayTrait> DeviceInterface<I2C, DELAY> {
-    pub fn new(i2c: I2C, delay: DELAY) -> Self {
+    #[must_use]
+    pub const fn new(i2c: I2C, delay: DELAY) -> Self {
         DeviceInterface {
             i2c,
             delay,
-            config: Config::default(),
+            config: Config::new(),
         }
+    }
+
+    #[must_use]
+    pub const fn new_with_config(i2c: I2C, delay: DELAY, config: Config) -> Self {
+        DeviceInterface { i2c, delay, config }
     }
 }
 

--- a/src/versions/r1.rs
+++ b/src/versions/r1.rs
@@ -27,9 +27,21 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R1<I2C, DELAY> {
 
     pub fn new_with_config(i2c: I2C, delay: DELAY, config: Config) -> Self {
         Bq40z50R1 {
-            device: Device::new(DeviceInterface { i2c, delay, config }),
+            device: Device::new(DeviceInterface::new_with_config(i2c, delay, config)),
             capacity_mode_state: Cell::new(CapacityModeState::Milliamps),
         }
+    }
+
+    /// Change interface config.
+    ///
+    /// Concurrency is guaranteed by the mutable borrow, ensuring the config cannot change
+    /// while a register transaction is in flight.
+    pub fn update_config(&mut self, config: Config) {
+        self.device.interface.config = config;
+    }
+
+    pub fn config(&self) -> Config {
+        self.device.interface.config
     }
 
     fn set_capacity_mode_state(&self, battery_mode_fields: BatteryModeFields) {

--- a/src/versions/r3.rs
+++ b/src/versions/r3.rs
@@ -28,9 +28,21 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R3<I2C, DELAY> {
 
     pub fn new_with_config(i2c: I2C, delay: DELAY, config: Config) -> Self {
         Bq40z50R3 {
-            device: Device::new(DeviceInterface { i2c, delay, config }),
+            device: Device::new(DeviceInterface::new_with_config(i2c, delay, config)),
             capacity_mode_state: Cell::new(CapacityModeState::Milliamps),
         }
+    }
+
+    /// Change interface config.
+    ///
+    /// Concurrency is guaranteed by the mutable borrow, ensuring the config cannot change
+    /// while a register transaction is in flight.
+    pub fn update_config(&mut self, config: Config) {
+        self.device.interface.config = config;
+    }
+
+    pub fn config(&self) -> Config {
+        self.device.interface.config
     }
 
     fn set_capacity_mode_state(&self, battery_mode_fields: BatteryModeFields) {

--- a/src/versions/r4.rs
+++ b/src/versions/r4.rs
@@ -28,9 +28,21 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R4<I2C, DELAY> {
 
     pub fn new_with_config(i2c: I2C, delay: DELAY, config: Config) -> Self {
         Bq40z50R4 {
-            device: Device::new(DeviceInterface { i2c, delay, config }),
+            device: Device::new(DeviceInterface::new_with_config(i2c, delay, config)),
             capacity_mode_state: Cell::new(CapacityModeState::Milliamps),
         }
+    }
+
+    /// Change interface config.
+    ///
+    /// Concurrency is guaranteed by the mutable borrow, ensuring the config cannot change
+    /// while a register transaction is in flight.
+    pub fn update_config(&mut self, config: Config) {
+        self.device.interface.config = config;
+    }
+
+    pub fn config(&self) -> Config {
+        self.device.interface.config
     }
 
     fn set_capacity_mode_state(&self, battery_mode_fields: BatteryModeFields) {

--- a/src/versions/r5.rs
+++ b/src/versions/r5.rs
@@ -28,9 +28,21 @@ impl<I2C: I2cTrait, DELAY: DelayTrait> Bq40z50R5<I2C, DELAY> {
 
     pub fn new_with_config(i2c: I2C, delay: DELAY, config: Config) -> Self {
         Bq40z50R5 {
-            device: Device::new(DeviceInterface { i2c, delay, config }),
+            device: Device::new(DeviceInterface::new_with_config(i2c, delay, config)),
             capacity_mode_state: Cell::new(CapacityModeState::Milliamps),
         }
+    }
+
+    /// Change interface config.
+    ///
+    /// Concurrency is guaranteed by the mutable borrow, ensuring the config cannot change
+    /// while a register transaction is in flight.
+    pub fn update_config(&mut self, config: Config) {
+        self.device.interface.config = config;
+    }
+
+    pub fn config(&self) -> Config {
+        self.device.interface.config
     }
 
     fn set_capacity_mode_state(&self, battery_mode_fields: BatteryModeFields) {


### PR DESCRIPTION
- PEC, timeout time, and number of retries can now be changed without creating a new instance of the driver
- Uprev to v0.8.1
- Remove deprecated `authors` field in Cargo.toml